### PR TITLE
chore: lint-stagedの除外設定にdocs/specs/を追加

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -5,10 +5,12 @@ module.exports = {
 	// Biomeによるリントとフォーマット（CLAUDE.mdを除外）
 	"**/*.{js,jsx,ts,tsx,json}": ["npm run lint:fix", "npm run format:fix"],
 	"**/*.md": (filenames) => {
-		// CLAUDE.mdと.claudeディレクトリを除外
+		// CLAUDE.md、.claudeディレクトリ、docs/specs/を除外
 		const filteredFiles = filenames.filter(
 			(filename) =>
-				!filename.includes("CLAUDE.md") && !filename.includes(".claude/"),
+				!filename.includes("CLAUDE.md") &&
+				!filename.includes(".claude/") &&
+				!filename.includes("docs/specs/"),
 		);
 		if (filteredFiles.length === 0) return [];
 		return [


### PR DESCRIPTION
- docs/specs/ディレクトリを自動フォーマット対象から除外
- 仕様書ファイルの手動管理を可能にする