### PR TITLE
docs: スキル・コマンド利用ガイドを追加

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,0 +1,188 @@
+# Claude Code スキル・コマンド利用ガイド
+
+このガイドは、プロジェクトで使用する開発自動化コマンドの利用方法を説明します。
+**新しく参加した開発者が5分でキャッチアップできる**ことを目的としています。
+
+---
+
+## コマンド一覧
+
+| コマンド | 用途 | 推奨シーン |
+|---------|------|----------|
+| `/spec-create` | 仕様書作成（ATDD形式） | 新機能開発の開始時 |
+| `/task-exec` | タスク実行（品質保証付き） | 重要なタスクの確実な完了 |
+| `/task-vibe-kanban-loop` | 複数タスク自動連続実行 | 大量の定型作業 |
+| `/frontend-implement` | フロントエンド実装 | UI実装時 |
+| `/start-dev` | 開発環境起動 | 開発開始時 |
+
+---
+
+## どのコマンドを使うべきか？
+
+```mermaid
+flowchart TD
+    Start([タスクがある]) --> Q1{仕様書は<br/>存在する？}
+    Q1 -->|No| SpecCreate["/spec-create を実行<br/>仕様書を作成"]
+    Q1 -->|Yes| Q2{タスク数と<br/>重要度は？}
+
+    SpecCreate --> Q2
+
+    Q2 -->|1〜3個の重要タスク| TaskExec["/task-exec #Issue番号<br/>品質保証ループ付きで確実に完了"]
+    Q2 -->|4個以上 or 定型作業| VibeLoop["/task-vibe-kanban-loop<br/>自動連続実行で効率的に消化"]
+
+    TaskExec --> Done([タスク完了])
+    VibeLoop --> Done
+
+    style SpecCreate fill:#2196f3,color:#fff
+    style TaskExec fill:#ff9800,color:#fff
+    style VibeLoop fill:#4caf50,color:#fff
+```
+
+### 判断基準
+
+| 状況 | 推奨コマンド |
+|------|-------------|
+| 新機能開発を始める | `/spec-create` |
+| 複雑な実装、品質が重要 | `/task-exec` |
+| 単純な作業が大量にある | `/task-vibe-kanban-loop` |
+| UIコンポーネントを実装 | `/frontend-implement` |
+
+---
+
+## 状態確認方法
+
+### タスクの進捗状態を確認する場所
+
+| 情報 | 確認場所 | 状態表示 |
+|------|----------|----------|
+| タスク完了状況 | GitHub Issue | `[x]` = 完了, `[ ]` = 未着手 |
+| 着手中タスク | GitHub Issue | `<!-- 🔄 着手中 -->` コメント |
+| 実行中エージェント | Vibe-Kanban UI | ステータス表示 |
+
+### Vibe-Kanban UIの起動
+
+```bash
+npx vibe-kanban
+```
+
+起動後、ブラウザでUIが開き、実行中のタスクと進捗を確認できます。
+
+### GitHub Issueでの状態確認
+
+```bash
+# Issue内容を確認
+gh issue view 123
+
+# チェックボックスの状態を確認
+# - [ ] = 未着手
+# - [x] = 完了
+# - <!-- 🔄 着手中 --> = 現在実行中
+```
+
+---
+
+## 「自動連続実行」について（重要）
+
+このプロジェクトでは「自動連続実行」という用語を使用します。
+
+### 用語の定義
+
+| コマンド | 動作 |
+|---------|------|
+| `/task-exec` | 1タスクを確実に完了（品質保証ループ付き） |
+| `/task-vibe-kanban-loop` | 複数タスクを**順番に**自動実行 |
+
+### 重要な注意
+
+- 複数エージェントの**同時実行ではありません**
+- タスクは1つずつ順番に処理されます
+- 「並列」「並行」という表現は使用しません
+
+### 仕組みの違い
+
+```
+/task-exec の動作:
+  タスク選定 → 実装 → レビュー → QA → 完了
+                 ↑__________________|
+                    失敗時ループ
+
+/task-vibe-kanban-loop の動作:
+  タスク選定 → Vibe登録 → エージェント実行 → 次タスク選定 → ...
+       ↑_______________________________________________|
+                         自動ループ（最大30回待機）
+```
+
+---
+
+## コマンド詳細
+
+### `/spec-create`
+
+仕様書を段階的に作成します。
+
+```bash
+# 機能説明から作成
+/spec-create "ユーザー認証機能の実装"
+
+# Asanaタスクから作成
+/spec-create https://app.asana.com/0/project/task-id
+
+# 既存仕様書を修正
+/spec-create "改善内容" /docs/specs/issues/auth/20250111-auth/
+```
+
+**出力物**:
+- `requirements.md` - 要件定義書（受け入れ基準含む）
+- `design.md` - 設計書
+- GitHub Issue - タスク一覧
+
+### `/task-exec`
+
+タスクを品質保証付きで確実に完了します。
+
+```bash
+# 自動選定で実行
+/task-exec #123
+
+# 特定のタスクグループを指定
+/task-exec #123 1.1
+
+# Issue番号のみ（#なし）
+/task-exec 123
+```
+
+**特徴**:
+- 品質保証ループ: レビュー/QA失敗時は自動的に実装に戻る
+- 完了まで自動進行: ユーザー確認なしに次フェーズへ
+
+### `/task-vibe-kanban-loop`
+
+複数タスクを自動連続実行します。
+
+```bash
+# 基本的な実行
+/task-vibe-kanban-loop #123
+
+# 自然言語で詳細指定
+/task-vibe-kanban-loop Issue #123のタスク4.1まで実行
+```
+
+**特徴**:
+- 1タスクずつ選定→登録→実行を繰り返し
+- 最大30回まで待機してタスクを探す
+
+---
+
+## 詳細ドキュメント
+
+- [クイックリファレンス](./quick-reference.md) - コピペ用早見表とFAQ
+- [タスク実行ワークフロー詳細](../instructions/task-execute.md) - task-execの詳細仕様
+- [Vibe-Kanban自動実行ガイド](../instructions/task-vibe-kanban-loop.md) - task-vibe-kanban-loopの詳細
+
+---
+
+## 関連ドキュメント
+
+- [CLAUDE.md](../../CLAUDE.md) - プロジェクト全体の指示書
+- [タスク管理ガイドライン](../steering/task-management.md) - ブランチ戦略等
+- [コーディング規約](../coding-standards.mdc) - コードスタイル

--- a/docs/guides/quick-reference.md
+++ b/docs/guides/quick-reference.md
@@ -1,0 +1,220 @@
+# クイックリファレンス
+
+コピペで使えるコマンド早見表とよくある質問集です。
+
+---
+
+## コマンド早見表
+
+### 基本コマンド
+
+| やりたいこと | コマンド |
+|-------------|---------|
+| 仕様書を作成 | `/spec-create "機能の説明"` |
+| タスクを実行（1つ） | `/task-exec #123` |
+| 特定タスクを指定して実行 | `/task-exec #123 1.1` |
+| 複数タスクを自動消化 | `/task-vibe-kanban-loop #123` |
+| 開発環境を起動 | `/start-dev` |
+| フロントエンド実装 | `/frontend-implement "機能名"` |
+
+### 確認コマンド（ターミナル）
+
+```bash
+# Issue内容を確認
+gh issue view 123
+
+# Issueのタスク一覧を確認
+gh issue view 123 --comments
+
+# Vibe-Kanban UIを起動
+npx vibe-kanban
+
+# 現在のブランチを確認
+git branch --show-current
+```
+
+---
+
+## よくある質問（FAQ）
+
+### Q1: タスクが選定されない
+
+**症状**: `/task-exec`を実行しても「実行可能なタスクがありません」と表示される
+
+**原因**: 依存タスクが未完了
+
+**対処法**:
+
+1. GitHub Issueで依存関係を確認
+   ```bash
+   gh issue view 123
+   ```
+
+2. タスク一覧で「**依存関係**:」の記載を確認
+   ```markdown
+   - [ ] **1.2 メール送信機能**
+     - **依存関係**: 1.1  ← これが完了していないと実行できない
+   ```
+
+3. 先行タスクを先に完了させる
+   ```bash
+   /task-exec #123 1.1
+   ```
+
+---
+
+### Q2: Vibe-Kanbanの起動・設定方法
+
+**起動方法**:
+
+```bash
+npx vibe-kanban
+```
+
+ブラウザが自動で開き、UIが表示されます。
+
+**プロジェクトIDの確認**:
+
+```
+mcp__vibe_kanban__list_projects
+```
+
+**MCP設定（既に設定済み）**:
+
+`.claude/settings.json` に以下が設定されています：
+
+```json
+{
+  "mcpServers": {
+    "vibe_kanban": {
+      "command": "npx",
+      "args": ["-y", "vibe-kanban-mcp"]
+    }
+  }
+}
+```
+
+**注意**: `npx vibe-kanban`（UI）と `vibe-kanban-mcp`（MCP）は別パッケージです。
+
+---
+
+### Q3: 品質ループが無限に回る
+
+**症状**: `/task-exec`でレビュー→実装→レビュー...のループが終わらない
+
+**原因**:
+- テストが常に失敗している
+- レビューで検出される問題が解消されない
+- 仮実装（TODO/FIXME）が残っている
+
+**対処法**:
+
+1. **エラーログを確認**
+   - task-reviewerの出力で「MAJOR」の指摘を確認
+   - task-qaの出力でテスト失敗理由を確認
+
+2. **手動で修正**
+   ```bash
+   # ループを中断（Ctrl+C）
+   # 問題箇所を手動で修正
+   # 再実行
+   /task-exec #123
+   ```
+
+3. **仮実装を検索**
+   ```bash
+   grep -r "TODO\|FIXME\|throw new Error" src/
+   ```
+
+4. **テストを個別実行**
+   ```bash
+   pnpm test
+   pnpm typecheck
+   pnpm lint
+   ```
+
+---
+
+### Q4: 複数Issueを同時進行したい
+
+**方法**: 別ブランチで別ターミナルから実行
+
+**手順**:
+
+1. **ターミナル1**: Issue #123を実行
+   ```bash
+   git checkout -b feature/issue-123
+   /task-exec #123
+   ```
+
+2. **ターミナル2**: Issue #124を実行（別ディレクトリで）
+   ```bash
+   # 別のworktreeを作成
+   git worktree add ../project-issue-124 -b feature/issue-124
+   cd ../project-issue-124
+   /task-exec #124
+   ```
+
+**重要な注意**:
+
+- 同一Issueの同時実行は**禁止**
+- 同じファイルを変更する可能性がある場合は避ける
+- Vibe-Kanbanで状態を確認してから実行
+
+---
+
+## トラブルシューティング
+
+### 開発サーバーが起動しない
+
+```bash
+# 依存関係を再インストール
+pnpm install
+
+# Prismaクライアントを再生成
+pnpm db:generate
+
+# キャッシュをクリア
+rm -rf node_modules/.cache
+```
+
+### MCPサーバーに接続できない
+
+```bash
+# MCP設定を確認
+cat .claude/settings.json
+
+# Vibe-Kanbanが起動しているか確認
+npx vibe-kanban
+```
+
+### GitHub認証エラー
+
+```bash
+# gh CLIの認証状態を確認
+gh auth status
+
+# 再認証
+gh auth login
+```
+
+---
+
+## 状態アイコン一覧
+
+| アイコン | 意味 |
+|---------|------|
+| `[ ]` | 未着手 |
+| `[x]` | 完了 |
+| `<!-- 🔄 着手中 -->` | 現在実行中 |
+| `PASS` | レビュー/QA合格 |
+| `MAJOR` | 重大な問題あり（要修正） |
+| `MINOR` | 軽微な問題（後続で対応可） |
+
+---
+
+## 関連ドキュメント
+
+- [コマンド利用ガイド](./README.md) - コマンドの詳細説明
+- [タスク実行ワークフロー](../instructions/task-execute.md) - task-execの仕様
+- [Vibe-Kanbanガイド](../instructions/task-vibe-kanban-loop.md) - 自動連続実行の仕様

--- a/docs/instructions/task-execute.md
+++ b/docs/instructions/task-execute.md
@@ -1,5 +1,7 @@
 # Dr.Love Demo App - 開発ワークフロー
 
+> **クイックスタート**: [スキル・コマンド利用ガイド](../guides/README.md) | [クイックリファレンス](../guides/quick-reference.md)
+
 このドキュメントでは、`/spec-create`と`/task-exec`コマンドを使用したATDD（受け入れテスト駆動開発）に基づく開発ワークフローについて説明します。
 
 ## 概要
@@ -365,7 +367,7 @@ Step 4: GitHub Issueにタスク一覧を記述
 | コマンド | 用途 | 品質保証 | 推奨シーン |
 |---------|------|---------|----------|
 | **`/task-exec`** | 重要タスクの確実な完了 | ✅ 合格まで自動ループ | 複雑な実装、品質重視 |
-| **`/task-vibe-kanban-loop`** | 大量タスクの自動消化 | ❌ 各タスクは別プロセス | 定型作業、並行開発 |
+| **`/task-vibe-kanban-loop`** | 大量タスクの自動消化 | ❌ 各タスクは別プロセス | 定型作業、自動連続実行 |
 
 **詳細な使い分け基準**: [task-vibe-kanban-loop.md](./task-vibe-kanban-loop.md#task-execとの使い分け)
 

--- a/docs/instructions/task-vibe-kanban-loop.md
+++ b/docs/instructions/task-vibe-kanban-loop.md
@@ -1,5 +1,7 @@
 # `/task-vibe-kanban-loop` コマンド
 
+> **クイックスタート**: [スキル・コマンド利用ガイド](../guides/README.md) | [クイックリファレンス](../guides/quick-reference.md)
+
 ## 概要
 
 タスクファイルから実行可能なタスクを自動選定し、Vibe-Kanbanに登録して連続実行するループ管理コマンド。
@@ -174,7 +176,7 @@ Vibe-KanbanをMCPサーバーとして使用するため、`claude_desktop_confi
 | コマンド | 用途 | 品質保証 | 推奨シーン |
 |---------|------|---------|----------|
 | **`/task-exec`** | 重要タスクの確実な完了 | ✅ 合格まで自動ループ | 複雑な実装、品質重視 |
-| **`/task-vibe-kanban-loop`** | 大量タスクの自動消化 | ❌ 各タスクは別プロセス | 定型作業、並行開発 |
+| **`/task-vibe-kanban-loop`** | 大量タスクの自動消化 | ❌ 各タスクは別プロセス | 定型作業、自動連続実行 |
 
 **詳細**: [task-execute.md](./task-execute.md#task-execとの使い分け)
 


### PR DESCRIPTION
## Summary

- スキル・コマンド利用ガイドを新規作成
- 新人開発者が5分でキャッチアップできるドキュメント整備
- 「並列実行」という誤解を招く表現を「自動連続実行」に統一

## 変更内容

### 新規作成
- `docs/guides/README.md`: コマンド一覧、意思決定フローチャート、状態確認方法
- `docs/guides/quick-reference.md`: コピペ用早見表、FAQ4項目

### 修正
- `docs/instructions/task-execute.md`: ガイドへのリンク追加、表現統一
- `docs/instructions/task-vibe-kanban-loop.md`: 同上

## 背景

調査の結果、以下の問題が判明：
- `/task-exec`に並列・継続着手の仕組みはない（単一タスク特化）
- `/task-vibe-kanban-loop`は「自動連続実行」であり、同時並列ではない
- 「並行開発」という誤解を招く表現が使用されていた
- ドキュメントが分散しており全体像を把握しにくかった

## Test plan
- [ ] docs/guides/README.md のmermaidフローチャートが正しく表示される
- [ ] docs/guides/quick-reference.md のFAQが正確
- [ ] 既存ドキュメントへのリンクが正しく機能する