### PR TITLE
docs: update-presetコマンドをpreset:updateスクリプト(内部開発用)に変更 (Vibe Kanban)

### DIFF
--- a/docs/specs/issues/cli/issue21-sync-command/qa-tests/README.md
+++ b/docs/specs/issues/cli/issue21-sync-command/qa-tests/README.md
@@ -131,22 +131,22 @@ grep -n "<<<<<<< LOCAL" .claude/commands/einja/task-exec.md
 # メタデータ確認
 cat .einja-sync.json | jq '.'
 
-# === update-preset コマンド（CLIリポジトリ内で実行） ===
+# === preset:update スクリプト（CLIリポジトリ内で実行、内部開発用） ===
 
 # 基本的なプリセット更新
-npx @einja/cli update-preset
+pnpm preset:update
 
 # ドライラン（差分確認のみ）
-npx @einja/cli update-preset --dry-run
+pnpm preset:update --dry-run
 
 # 特定プリセットのみ更新
-npx @einja/cli update-preset --preset turborepo-pandacss
+pnpm preset:update --preset turborepo-pandacss
 
 # 強制上書き（確認スキップ）
-npx @einja/cli update-preset --force
+pnpm preset:update --force
 
 # JSON出力
-npx @einja/cli update-preset --json > update-result.json
+pnpm preset:update --json > update-result.json
 
 # プリセットディレクトリ確認
 ls -la packages/cli/presets/turborepo-pandacss/.claude/commands/einja/
@@ -263,8 +263,8 @@ pnpm build
   - AC8.3: ログとJSONの分離出力
 
 ### Phase 4: プリセット更新機能（P1）
-- **Story 10**: プリセット更新コマンド
-  - AC10.1: CLIリポジトリ検出と実行
+- **Story 10**: プリセット更新スクリプト（内部開発用）
+  - AC10.1: `pnpm preset:update`でCLIリポジトリ検出と実行
   - AC10.2: 全プリセットへの一括更新
   - AC10.3: .claude/ディレクトリの同期
   - AC10.4: docs/steering, docs/templatesの同期
@@ -272,7 +272,7 @@ pnpm build
   - AC10.6: --presetオプションでの選択的更新
   - AC10.7: CLIリポジトリ外での実行エラー
   - AC10.8: --dry-runでの差分確認
-- **Story 11**: プリセット更新のJSON出力
+- **Story 11**: プリセット更新スクリプトのJSON出力
   - AC11.1: --jsonでのJSON形式出力
   - AC11.2: 更新されたファイル一覧の出力
 

--- a/docs/specs/issues/cli/issue21-sync-command/qa-tests/scenarios.md
+++ b/docs/specs/issues/cli/issue21-sync-command/qa-tests/scenarios.md
@@ -248,7 +248,7 @@
 ## シナリオ8: プリセット更新の基本フロー
 
 ### 目的
-CLIリポジトリ内でupdate-presetコマンドを実行し、プロジェクトの.claude/やdocs/の内容がプリセットに正しく反映されることを確認する。
+CLIリポジトリ内でpreset:updateスクリプトを実行し、プロジェクトの.claude/やdocs/の内容がプリセットに正しく反映されることを確認する。
 
 ### 関連
 - **受け入れ条件**: AC10.1, AC10.2, AC10.3, AC10.4, AC10.5
@@ -267,8 +267,8 @@ CLIリポジトリ内でupdate-presetコマンドを実行し、プロジェク�
 |------|------|---------|--------|------|
 | 1 | CLIリポジトリのルートに移動 | - | - | - |
 | 2 | .claude/commands/einja/test-file.md を新規作成 | - | - | テストデータ準備 |
-| 3 | npx @einja/cli update-preset --dry-run 実行 | ドライラン確認 | 変更予定ファイル一覧表示、実際のファイル変更なし | - |
-| 4 | npx @einja/cli update-preset 実行 | プリセット更新成功 | ✅ 更新完了メッセージ | - |
+| 3 | pnpm preset:update --dry-run 実行 | ドライラン確認 | 変更予定ファイル一覧表示、実際のファイル変更なし | - |
+| 4 | pnpm preset:update 実行 | プリセット更新成功 | ✅ 更新完了メッセージ | - |
 | 5 | ls packages/cli/presets/turborepo-pandacss/.claude/commands/einja/ 実行 | ファイルコピー確認 | test-file.md が存在 | - |
 | 6 | ls packages/cli/presets/minimal/.claude/commands/einja/ 実行 | 全プリセット更新確認 | test-file.md が存在 | - |
 | 7 | diff .claude/commands/einja/test-file.md packages/cli/presets/turborepo-pandacss/.claude/commands/einja/test-file.md 実行 | 内容一致確認 | 差分なし | - |
@@ -305,7 +305,7 @@ CLIリポジトリ内でupdate-presetコマンドを実行し、プロジェク�
 | - | .claude/skills/einja/skill-test.md 作成 | - | - | - |
 | - | docs/steering/steer-test.md 作成 | - | - | - |
 | - | docs/templates/tmpl-test.md 作成 | - | - | - |
-| 3 | npx @einja/cli update-preset 実行 | 全ディレクトリ更新成功 | ✅ 更新完了メッセージ | - |
+| 3 | pnpm preset:update 実行 | 全ディレクトリ更新成功 | ✅ 更新完了メッセージ | - |
 | 4 | 各プリセットディレクトリを確認 | マッピング確認 | 下記期待値を満たす | - |
 | - | ls packages/cli/presets/*/\`.claude/commands/einja/\` | cmd-test.md 存在 | - |
 | - | ls packages/cli/presets/*/\`.claude/agents/einja/\` | agent-test.md 存在 | - |
@@ -313,7 +313,7 @@ CLIリポジトリ内でupdate-presetコマンドを実行し、プロジェク�
 | - | ls packages/cli/presets/*/\`docs/einja/steering/\` | steer-test.md 存在 | - |
 | - | ls packages/cli/presets/*/\`docs/einja/templates/\` | tmpl-test.md 存在 | - |
 | 5 | _プレフィックスファイルを作成 (.claude/commands/einja/_private.md) | - | - | - |
-| 6 | npx @einja/cli update-preset 実行 | _ ファイルスキップ | _private.md がプリセットに存在しない | - |
+| 6 | pnpm preset:update 実行 | _ ファイルスキップ | _private.md がプリセットに存在しない | - |
 | 7 | ls packages/cli/presets/turborepo-pandacss/.claude/commands/einja/_private.md 実行 | ファイル不在確認 | "No such file or directory" | - |
 
 ### 実行ログ
@@ -343,10 +343,10 @@ CLIリポジトリ内でupdate-presetコマンドを実行し、プロジェク�
 |------|------|---------|--------|------|
 | 1 | CLIリポジトリのルートに移動 | - | - | - |
 | 2 | .claude/commands/einja/selective-test.md を新規作成 | - | - | テストデータ準備 |
-| 3 | npx @einja/cli update-preset --preset turborepo-pandacss 実行 | 選択的更新成功 | ✅ 更新完了メッセージ | - |
+| 3 | pnpm preset:update --preset turborepo-pandacss 実行 | 選択的更新成功 | ✅ 更新完了メッセージ | - |
 | 4 | ls packages/cli/presets/turborepo-pandacss/.claude/commands/einja/ 実行 | turborepo-pandacss更新確認 | selective-test.md が存在 | - |
 | 5 | ls packages/cli/presets/minimal/.claude/commands/einja/ 実行 | minimal未更新確認 | selective-test.md が存在しない | - |
-| 6 | npx @einja/cli update-preset --preset invalid-preset 実行 | 無効プリセットエラー | エラーメッセージ、有効なプリセット一覧表示 | - |
+| 6 | pnpm preset:update --preset invalid-preset 実行 | 無効プリセットエラー | エラーメッセージ、有効なプリセット一覧表示 | - |
 
 ### 実行ログ
 （実施後に記載）
@@ -356,10 +356,10 @@ CLIリポジトリ内でupdate-presetコマンドを実行し、プロジェク�
 ## シナリオ11: CLIリポジトリ外での実行エラー
 
 ### 目的
-update-presetコマンドをCLIリポジトリ外で実行した場合、適切なエラーメッセージが表示されることを確認する。
+preset:updateスクリプトをCLIリポジトリ外で実行した場合、適切なエラーメッセージが表示されることを確認する。
 
 ### 関連
-- **受け入れ条件**: AC10.7
+- **受け入れ条件**: AC10.8
 - **関連タスク**: Story 10
 
 ### 実施タイミング
@@ -370,8 +370,8 @@ update-presetコマンドをCLIリポジトリ外で実行した場合、適切�
 | Step | 操作 | 確認項目 | 期待値 | 結果 |
 |------|------|---------|--------|------|
 | 1 | 任意の非CLIリポジトリプロジェクトに移動 | - | - | - |
-| 2 | npx @einja/cli update-preset 実行 | CLIリポジトリ外エラー | 終了コード1、"CLIリポジトリ内で実行してください"エラーメッセージ | - |
-| 3 | npx @einja/cli update-preset --json 実行 | エラーJSON出力 | {"status": "error", "error": {...}} 形式 | - |
+| 2 | pnpm preset:update 実行 | CLIリポジトリ外エラー | 終了コード1、"CLIリポジトリ内で実行してください"エラーメッセージ | - |
+| 3 | pnpm preset:update --json 実行 | エラーJSON出力 | {"status": "error", "error": {...}} 形式 | - |
 
 ### 実行ログ
 （実施後に記載）
@@ -400,7 +400,7 @@ update-presetコマンドをCLIリポジトリ外で実行した場合、適切�
 |------|------|---------|--------|------|
 | 1 | CLIリポジトリのルートに移動 | - | - | - |
 | 2 | .claude/commands/einja/json-test.md を新規作成 | - | - | テストデータ準備 |
-| 3 | npx @einja/cli update-preset --json > update-result.json 実行 | JSON出力 | 標準出力にJSON形式で結果出力 | - |
+| 3 | pnpm preset:update --json > update-result.json 実行 | JSON出力 | 標準出力にJSON形式で結果出力 | - |
 | 4 | cat update-result.json \| jq '.' 実行 | JSON妥当性確認 | 有効なJSON形式 | - |
 | 5 | cat update-result.json \| jq '.status' 実行 | ステータス確認 | "success" | - |
 | 6 | cat update-result.json \| jq '.summary' 実行 | サマリー確認 | total, copied, skipped等のキーが存在 | - |
@@ -412,17 +412,17 @@ update-presetコマンドをCLIリポジトリ外で実行した場合、適切�
 
 ---
 
-## シナリオ13: sync→update-preset→sync の双方向ワークフロー
+## シナリオ13: sync→preset:update→sync の双方向ワークフロー
 
 ### 目的
-CLIの変更をプリセットに反映（update-preset）し、その後別のプロジェクトでsyncコマンドを実行して変更が正しく伝播することを確認する。
+CLIの変更をプリセットに反映（preset:update）し、その後別のプロジェクトでsyncコマンドを実行して変更が正しく伝播することを確認する。
 
 ### 関連
 - **受け入れ条件**: AC10.1, AC10.2, AC1.1, AC1.3
 - **関連タスク**: Story 1, 10
 
 ### 実施タイミング
-- **Phase 4完了後**: 全Step実施（sync + update-preset両方が実装される）
+- **Phase 4完了後**: 全Step実施（sync + preset:update両方が実装される）
 
 ### 前提条件
 - einja/cliリポジトリをクローンしていること
@@ -434,13 +434,13 @@ CLIの変更をプリセットに反映（update-preset）し、その後別の�
 |------|------|---------|--------|------|
 | 1 | CLIリポジトリのルートに移動 | - | - | - |
 | 2 | .claude/commands/einja/new-feature.md を新規作成（内容: "Version 1.0"） | - | - | 新機能追加を想定 |
-| 3 | npx @einja/cli update-preset 実行 | プリセット更新成功 | ✅ 更新完了メッセージ | - |
+| 3 | pnpm preset:update 実行 | プリセット更新成功 | ✅ 更新完了メッセージ | - |
 | 4 | cat packages/cli/presets/turborepo-pandacss/.claude/commands/einja/new-feature.md 実行 | プリセット内容確認 | "Version 1.0" が含まれる | - |
 | 5 | テスト用ユーザープロジェクトに移動 | - | - | - |
 | 6 | npx @einja/cli sync 実行（ローカルCLIパッケージから） | sync実行 | ✅ 同期完了メッセージ | - |
 | 7 | cat .claude/commands/einja/new-feature.md 実行 | ユーザープロジェクト内容確認 | "Version 1.0" が含まれる | - |
 | 8 | CLIリポジトリに戻り、new-feature.md を更新（内容: "Version 2.0"） | - | - | バージョンアップを想定 |
-| 9 | npx @einja/cli update-preset 実行 | プリセット再更新成功 | ✅ 更新完了メッセージ | - |
+| 9 | pnpm preset:update 実行 | プリセット再更新成功 | ✅ 更新完了メッセージ | - |
 | 10 | テスト用ユーザープロジェクトに移動 | - | - | - |
 | 11 | npx @einja/cli sync 実行 | 更新取り込み | ✅ 同期完了メッセージ | - |
 | 12 | cat .claude/commands/einja/new-feature.md 実行 | 更新内容確認 | "Version 2.0" が含まれる | - |
@@ -468,6 +468,6 @@ CLIの変更をプリセットに反映（update-preset）し、その後別の�
 | シナリオ10: 選択的プリセット更新 | - | - | - | 🔄 | Phase 4のみ |
 | シナリオ11: CLIリポジトリ外での実行エラー | - | - | - | 🔄 | Phase 4のみ |
 | シナリオ12: プリセット更新のJSON出力 | - | - | - | 🔄 | Phase 4のみ |
-| シナリオ13: sync→update-preset→sync の双方向ワークフロー | - | - | - | 🔄 | Phase 4のみ |
+| シナリオ13: sync→preset:update→sync の双方向ワークフロー | - | - | - | 🔄 | Phase 4のみ |
 
 **凡例**: ✅ PASS / ❌ FAIL / ⚠️ PARTIAL / 🔄 未実施


### PR DESCRIPTION
## 概要

`update-preset`コマンドを`preset:update`スクリプト（内部開発用npmスクリプト）に変更するため、Issue #21のすべての仕様書とGitHub Issueを更新しました。

## 変更内容

### 背景

当初、プリセット更新機能は`npx @einja/cli update-preset`という公開CLIコマンドとして設計されていました。しかし、この機能は開発者専用であり、一般ユーザーには不要な機能です。Codexとの方針検討の結果、以下の理由から内部npmスクリプトとして実装することが決定されました：

- **パッケージ肥大化の回避**: 開発者専用コードを公開パッケージに含めない
- **ユーザー混乱の防止**: 一般ユーザーが誤って実行するリスクを排除
- **保守性の向上**: CLIコマンドとしての複雑な処理が不要

### 主な変更

すべての仕様書で以下のパターンで統一的に変更しました：

| 変更前 | 変更後 |
|--------|--------|
| `npx @einja/cli update-preset` | `pnpm preset:update` |
| `update-preset コマンド` | `preset:update スクリプト（内部開発用）` |
| `src/commands/update-preset.ts` | `scripts/preset-update.ts` |
| 「このコマンドは...」 | 「このスクリプトは...」 |

### 修正ファイル

1. **requirements.md**
   - Story 10のタイトルと実装方針を更新
   - 全AC（AC10.1-AC10.8, AC11.1-AC11.2）のコマンド参照を変更
   - ユースケース（UC10-UC13）の説明を更新
   - ディレクトリ構造要件の配置先を`scripts/`に変更

2. **design/implementation.md**
   - セクションタイトルを「preset:update スクリプト設計（内部開発用）」に変更
   - 実装方針セクションを追加（公開CLIコマンドではなく内部npmスクリプトとして実装）
   - モジュール構成を`scripts/preset-update.ts`に変更
   - package.jsonスクリプト定義例を追加
   - 全コマンド例とシーケンス図を更新

3. **qa-tests/scenarios.md**
   - シナリオ8-13の全コマンド参照を更新
   - シナリオ11の目的を「preset:updateスクリプトをCLIリポジトリ外で実行した場合」に変更
   - シナリオ13のタイトルを「sync→preset:update→sync の双方向ワークフロー」に変更

4. **qa-tests/README.md**
   - Bashコマンド例のセクションタイトルを更新
   - 全コマンド例を`pnpm preset:update`に変更
   - Phase 4のACマッピング説明を更新

5. **GitHub Issue #21**
   - AS-IS/TO-BEセクションの説明を更新
   - 対応方針セクションを更新
   - Phase 4タスク一覧の全タスク説明とコマンド参照を更新

## 実装方針

```json
{
  "scripts": {
    "preset:update": "tsx scripts/preset-update.ts"
  }
}
```

- **配置場所**: `scripts/preset-update.ts`（公開パッケージの外）
- **実行方法**: `pnpm preset:update [options]`
- **CLIリポジトリ検出**: `packages/cli/package.json`の存在確認
- **エラーメッセージ**: CLIリポジトリ外で実行時は明確なエラーを表示

## レビューポイント

- [ ] すべての仕様書で用語が統一されているか
- [ ] コマンド実行例が正しく更新されているか
- [ ] 実装方針が明確に記述されているか
- [ ] GitHub Issueのタスク説明が整合しているか

---

This PR was written using [Vibe Kanban](https://vibekanban.com)
