### PR TITLE
fix: vibe-kanban MCP の破壊的変更に対応

### DIFF
--- a/packages/cli/src/commands/task-loop/index.ts
+++ b/packages/cli/src/commands/task-loop/index.ts
@@ -143,8 +143,8 @@ export async function taskLoopCommand(
   // タスク状態マネージャー初期化
   const stateManager = new TaskStateManager();
 
-  // 既存の Vibe-Kanban タスクを取得
-  const existingTasks = await vibeKanban.listTasks(projectId);
+  // 既存の Vibe-Kanban イシューを取得
+  const existingTasks = await vibeKanban.listIssues(projectId);
 
   // descriptionキャッシュを作成（パフォーマンス改善: getTaskを複数回呼ばない）
   console.log("📦 タスクのdescriptionをキャッシュ中...");
@@ -152,7 +152,7 @@ export async function taskLoopCommand(
   for (const task of existingTasks) {
     let description = task.description ?? null;
     if (!description) {
-      const fullTask = await vibeKanban.getTask(task.id);
+      const fullTask = await vibeKanban.getIssue(task.id);
       description = fullTask?.description ?? null;
     }
     descriptionCache.set(task.id, description);
@@ -232,8 +232,8 @@ export async function taskLoopCommand(
       loopCount++;
       console.log(`\n🔄 ポーリング #${loopCount} [${getTimestamp()}]`);
 
-      // Vibe-Kanban のタスク状態を取得
-      const currentTasks = await vibeKanban.listTasks(projectId);
+      // Vibe-Kanban のイシュー状態を取得
+      const currentTasks = await vibeKanban.listIssues(projectId);
 
       // 対象Issueに関連するDoneタスクの件数のみ表示
       const doneTasks = currentTasks.filter((t) => t.status === "done" && isTaskForThisIssue(t));
@@ -349,8 +349,8 @@ async function startExecutableTasks(
 
   console.log(`   📝 着手可能なタスク: ${executableGroups.length} 件`);
 
-  // 既存の Vibe-Kanban タスクを取得（cancelled 以外）
-  const existingTasks = await vibeKanban.listTasks(projectId);
+  // 既存の Vibe-Kanban イシューを取得（cancelled 以外）
+  const existingTasks = await vibeKanban.listIssues(projectId);
 
   // 対象Issueに属する既存タスクのタスクグループIDを収集
   const existingTaskGroupIdsForThisIssue = new Set<string>();
@@ -372,7 +372,7 @@ async function startExecutableTasks(
     // 旧形式の場合はdescriptionで判定
     let description = task.description;
     if (!description) {
-      const fullTask = await vibeKanban.getTask(task.id);
+      const fullTask = await vibeKanban.getIssue(task.id);
       description = fullTask?.description;
     }
     if (description?.includes(issuePatternInDesc)) {
@@ -398,24 +398,29 @@ async function startExecutableTasks(
     // タスク開始前に Phase ブランチを同期（リモートの最新を取得）
     await syncPhaseBranch(issueNumber, taskGroup.phaseNumber, issueBranch, baseBranch);
 
-    // タスク作成
-    console.log(`   📌 タスク作成: ${taskGroup.id} - ${taskGroup.name}`);
-    const taskId = await vibeKanban.createTask(projectId, title, description);
+    // イシュー作成
+    console.log(`   📌 イシュー作成: ${taskGroup.id} - ${taskGroup.name}`);
+    const issueId = await vibeKanban.createIssue(projectId, title, description);
 
     // マッピング登録
-    stateManager.registerTaskMapping(taskId, taskGroup.id);
+    stateManager.registerTaskMapping(issueId, taskGroup.id);
 
     // ステータスを inprogress に更新
-    await vibeKanban.updateTask(taskId, "inprogress");
+    await vibeKanban.updateIssue(issueId, "In Progress");
 
-    // タスク実行開始（Phase ブランチをベースに使用）
+    // ワークスペースセッション開始（Phase ブランチをベースに使用）
     const phaseBranch = getPhaseBranchNameNew(issueNumber, taskGroup.phaseNumber);
     try {
       const reposWithBranch = repos.map((repo) => ({
         repo_id: repo.id,
         base_branch: phaseBranch,
       }));
-      const attempt = await vibeKanban.startTaskAttempt(taskId, "CLAUDE_CODE", reposWithBranch);
+      const attempt = await vibeKanban.startWorkspaceSession(
+        issueId,
+        title,
+        "CLAUDE_CODE",
+        reposWithBranch
+      );
       console.log(
         `   ▶️  タスク開始: ${taskGroup.id} (base: ${phaseBranch}, attempt: ${attempt?.id ?? "unknown"})`
       );

--- a/packages/cli/src/commands/task-loop/lib/types.ts
+++ b/packages/cli/src/commands/task-loop/lib/types.ts
@@ -75,10 +75,10 @@ export interface VibeKanbanTask {
   status: "todo" | "inprogress" | "in-progress" | "done" | "cancelled";
 }
 
-/** Vibe-Kanban タスク実行試行 */
+/** Vibe-Kanban ワークスペースセッション */
 export interface VibeKanbanAttempt {
   id: string;
-  task_id: string;
+  issue_id?: string;
   executor: string;
   base_branch: string;
 }

--- a/packages/cli/src/commands/task-loop/lib/vibe-kanban-client.ts
+++ b/packages/cli/src/commands/task-loop/lib/vibe-kanban-client.ts
@@ -153,18 +153,19 @@ export class VibeKanbanClient {
   }
 
   /**
-   * タスク一覧を取得
+   * イシュー一覧を取得
    */
-  async listTasks(projectId: string): Promise<VibeKanbanTask[]> {
+  async listIssues(projectId?: string): Promise<VibeKanbanTask[]> {
     this.ensureConnected();
 
     const result = await this.client.callTool({
-      name: "list_tasks",
-      arguments: { project_id: projectId },
+      name: "list_issues",
+      arguments: projectId ? { project_id: projectId } : {},
     });
 
-    const parsed = this.parseToolResult<{ tasks: VibeKanbanTask[] }>(result, { tasks: [] });
-    return parsed.tasks;
+    // レスポンスは issues 配列として返る
+    const parsed = this.parseToolResult<VibeKanbanTask[]>(result, []);
+    return parsed;
   }
 
   /**
@@ -183,28 +184,28 @@ export class VibeKanbanClient {
   }
 
   /**
-   * タスクを取得
+   * イシューを取得
    */
-  async getTask(taskId: string): Promise<VibeKanbanTask | null> {
+  async getIssue(issueId: string): Promise<VibeKanbanTask | null> {
     this.ensureConnected();
 
     const result = await this.client.callTool({
-      name: "get_task",
-      arguments: { task_id: taskId },
+      name: "get_issue",
+      arguments: { issue_id: issueId },
     });
 
     return this.parseToolResult<VibeKanbanTask | null>(result, null);
   }
 
   /**
-   * タスクを作成
-   * @returns タスクID
+   * イシューを作成
+   * @returns イシューID
    */
-  async createTask(projectId: string, title: string, description: string): Promise<string> {
+  async createIssue(projectId: string, title: string, description: string): Promise<string> {
     this.ensureConnected();
 
     const result = await this.client.callTool({
-      name: "create_task",
+      name: "create_issue",
       arguments: {
         project_id: projectId,
         title,
@@ -212,50 +213,64 @@ export class VibeKanbanClient {
       },
     });
 
-    const parsed = this.parseToolResult<{ task_id: string } | null>(result, null);
-    if (!parsed?.task_id) {
-      throw new Error("タスクの作成に失敗しました");
+    // レスポンスから issue_id を取得（直接オブジェクトとして返る場合と、id プロパティの場合がある）
+    const parsed = this.parseToolResult<{ id?: string; issue_id?: string } | null>(result, null);
+    const issueId = parsed?.id ?? parsed?.issue_id;
+    if (!issueId) {
+      throw new Error("イシューの作成に失敗しました");
     }
-    return parsed.task_id;
+    return issueId;
   }
 
   /**
-   * タスクを更新
+   * イシューを更新
    */
-  async updateTask(taskId: string, status: "todo" | "inprogress" | "done"): Promise<void> {
+  async updateIssue(issueId: string, status: string): Promise<void> {
     this.ensureConnected();
 
     await this.client.callTool({
-      name: "update_task",
+      name: "update_issue",
       arguments: {
-        task_id: taskId,
+        issue_id: issueId,
         status,
       },
     });
   }
 
   /**
-   * タスク実行を開始
+   * ワークスペースセッションを開始
+   * @param issueId イシューID（オプショナル - ワークスペースをイシューに紐付ける場合に指定）
+   * @param title ワークスペースのタイトル（必須）
+   * @param executor 実行エージェント
+   * @param repos リポジトリ情報
    */
-  async startTaskAttempt(
-    taskId: string,
+  async startWorkspaceSession(
+    issueId: string | undefined,
+    title: string,
     executor: "CLAUDE_CODE",
     repos: Array<{ repo_id: string; base_branch: string }>
   ): Promise<VibeKanbanAttempt> {
     this.ensureConnected();
 
+    const args: Record<string, unknown> = {
+      title,
+      executor,
+      repos,
+    };
+
+    // issue_id がある場合のみ追加（オプショナル）
+    if (issueId) {
+      args.issue_id = issueId;
+    }
+
     const result = await this.client.callTool({
       name: "start_workspace_session",
-      arguments: {
-        task_id: taskId,
-        executor,
-        repos,
-      },
+      arguments: args,
     });
 
     const attempt = this.parseToolResult<VibeKanbanAttempt | null>(result, null);
     if (!attempt) {
-      throw new Error("タスク実行の開始に失敗しました");
+      throw new Error("ワークスペースセッションの開始に失敗しました");
     }
     return attempt;
   }


### PR DESCRIPTION
## Summary
- vibe-kanban MCPのAPI破壊的変更に追従
- `task` → `issue` への命名変更
- `start_workspace_session` のパラメータ変更（`title` 必須追加、`issue_id` オプショナル化）

## 変更内容

| 旧API | 新API |
|------|-------|
| `list_tasks` | `list_issues` |
| `get_task(task_id)` | `get_issue(issue_id)` |
| `create_task` | `create_issue` |
| `update_task(task_id)` | `update_issue(issue_id)` |
| `start_workspace_session(task_id, executor, repos)` | `start_workspace_session(title, executor, repos, issue_id?)` |

## 変更ファイル
- `packages/cli/src/commands/task-loop/lib/types.ts`
- `packages/cli/src/commands/task-loop/lib/vibe-kanban-client.ts`
- `packages/cli/src/commands/task-loop/index.ts`

## Test plan
- [x] `pnpm typecheck` 成功
- [x] `pnpm build` 成功
- [ ] `pnpm task:loop <issue-number>` で動作確認