### PR TITLE
fix: vibe-kanban MCP APIの破壊的変更に追従

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@einja/dev-cli",
-  "version": "0.1.25",
+  "version": "0.1.26",
   "description": "Einja CLI - .claude設定とテンプレート同期をnpxでインストール",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/cli/src/commands/task-loop/index.ts
+++ b/packages/cli/src/commands/task-loop/index.ts
@@ -144,7 +144,7 @@ export async function taskLoopCommand(
   const stateManager = new TaskStateManager();
 
   // 既存の Vibe-Kanban タスクを取得
-  const existingTasks = await vibeKanban.listTasks(projectId);
+  const existingTasks = await vibeKanban.listIssues(projectId);
 
   // descriptionキャッシュを作成（パフォーマンス改善: getTaskを複数回呼ばない）
   console.log("📦 タスクのdescriptionをキャッシュ中...");
@@ -152,7 +152,7 @@ export async function taskLoopCommand(
   for (const task of existingTasks) {
     let description = task.description ?? null;
     if (!description) {
-      const fullTask = await vibeKanban.getTask(task.id);
+      const fullTask = await vibeKanban.getIssue(task.id);
       description = fullTask?.description ?? null;
     }
     descriptionCache.set(task.id, description);
@@ -233,7 +233,7 @@ export async function taskLoopCommand(
       console.log(`\n🔄 ポーリング #${loopCount} [${getTimestamp()}]`);
 
       // Vibe-Kanban のタスク状態を取得
-      const currentTasks = await vibeKanban.listTasks(projectId);
+      const currentTasks = await vibeKanban.listIssues(projectId);
 
       // 対象Issueに関連するDoneタスクの件数のみ表示
       const doneTasks = currentTasks.filter((t) => t.status === "done" && isTaskForThisIssue(t));
@@ -350,7 +350,7 @@ async function startExecutableTasks(
   console.log(`   📝 着手可能なタスク: ${executableGroups.length} 件`);
 
   // 既存の Vibe-Kanban タスクを取得（cancelled 以外）
-  const existingTasks = await vibeKanban.listTasks(projectId);
+  const existingTasks = await vibeKanban.listIssues(projectId);
 
   // 対象Issueに属する既存タスクのタスクグループIDを収集
   const existingTaskGroupIdsForThisIssue = new Set<string>();
@@ -372,7 +372,7 @@ async function startExecutableTasks(
     // 旧形式の場合はdescriptionで判定
     let description = task.description;
     if (!description) {
-      const fullTask = await vibeKanban.getTask(task.id);
+      const fullTask = await vibeKanban.getIssue(task.id);
       description = fullTask?.description;
     }
     if (description?.includes(issuePatternInDesc)) {
@@ -381,7 +381,7 @@ async function startExecutableTasks(
   }
 
   // リポジトリ情報を取得（startTaskAttempt に必要）
-  const repos = await vibeKanban.listRepos(projectId);
+  const repos = await vibeKanban.listRepos();
 
   // 各タスクグループを Vibe-Kanban に登録
   for (const taskGroup of executableGroups) {
@@ -400,13 +400,13 @@ async function startExecutableTasks(
 
     // タスク作成
     console.log(`   📌 タスク作成: ${taskGroup.id} - ${taskGroup.name}`);
-    const taskId = await vibeKanban.createTask(projectId, title, description);
+    const issueId = await vibeKanban.createIssue(projectId, title, description);
 
     // マッピング登録
-    stateManager.registerTaskMapping(taskId, taskGroup.id);
+    stateManager.registerTaskMapping(issueId, taskGroup.id);
 
-    // ステータスを inprogress に更新
-    await vibeKanban.updateTask(taskId, "inprogress");
+    // ステータスを In Progress に更新
+    await vibeKanban.updateIssue(issueId, "In Progress");
 
     // タスク実行開始（Phase ブランチをベースに使用）
     const phaseBranch = getPhaseBranchNameNew(issueNumber, taskGroup.phaseNumber);
@@ -415,7 +415,7 @@ async function startExecutableTasks(
         repo_id: repo.id,
         base_branch: phaseBranch,
       }));
-      const attempt = await vibeKanban.startTaskAttempt(taskId, "CLAUDE_CODE", reposWithBranch);
+      const attempt = await vibeKanban.startWorkspaceSession(issueId, title, "CLAUDE_CODE", reposWithBranch);
       console.log(
         `   ▶️  タスク開始: ${taskGroup.id} (base: ${phaseBranch}, attempt: ${attempt?.id ?? "unknown"})`
       );

--- a/packages/cli/src/commands/task-loop/lib/types.ts
+++ b/packages/cli/src/commands/task-loop/lib/types.ts
@@ -75,10 +75,10 @@ export interface VibeKanbanTask {
   status: "todo" | "inprogress" | "in-progress" | "done" | "cancelled";
 }
 
-/** Vibe-Kanban タスク実行試行 */
+/** Vibe-Kanban ワークスペースセッション */
 export interface VibeKanbanAttempt {
   id: string;
-  task_id: string;
+  issue_id?: string;
   executor: string;
   base_branch: string;
 }

--- a/packages/cli/src/commands/task-loop/lib/vibe-kanban-client.ts
+++ b/packages/cli/src/commands/task-loop/lib/vibe-kanban-client.ts
@@ -153,58 +153,58 @@ export class VibeKanbanClient {
   }
 
   /**
-   * タスク一覧を取得
+   * イシュー一覧を取得
    */
-  async listTasks(projectId: string): Promise<VibeKanbanTask[]> {
+  async listIssues(projectId?: string): Promise<VibeKanbanTask[]> {
     this.ensureConnected();
 
     const result = await this.client.callTool({
-      name: "list_tasks",
-      arguments: { project_id: projectId },
+      name: "list_issues",
+      arguments: projectId ? { project_id: projectId } : {},
     });
 
-    const parsed = this.parseToolResult<{ tasks: VibeKanbanTask[] }>(result, { tasks: [] });
-    return parsed.tasks;
+    // レスポンスは直接配列として返る
+    return this.parseToolResult<VibeKanbanTask[]>(result, []);
   }
 
   /**
    * リポジトリ一覧を取得
    */
-  async listRepos(projectId: string): Promise<VibeKanbanRepo[]> {
+  async listRepos(): Promise<VibeKanbanRepo[]> {
     this.ensureConnected();
 
     const result = await this.client.callTool({
       name: "list_repos",
-      arguments: { project_id: projectId },
+      arguments: {},
     });
 
-    const parsed = this.parseToolResult<{ repos: VibeKanbanRepo[] }>(result, { repos: [] });
-    return parsed.repos;
+    // レスポンスは直接配列として返る
+    return this.parseToolResult<VibeKanbanRepo[]>(result, []);
   }
 
   /**
-   * タスクを取得
+   * イシューを取得
    */
-  async getTask(taskId: string): Promise<VibeKanbanTask | null> {
+  async getIssue(issueId: string): Promise<VibeKanbanTask | null> {
     this.ensureConnected();
 
     const result = await this.client.callTool({
-      name: "get_task",
-      arguments: { task_id: taskId },
+      name: "get_issue",
+      arguments: { issue_id: issueId },
     });
 
     return this.parseToolResult<VibeKanbanTask | null>(result, null);
   }
 
   /**
-   * タスクを作成
-   * @returns タスクID
+   * イシューを作成
+   * @returns イシューID
    */
-  async createTask(projectId: string, title: string, description: string): Promise<string> {
+  async createIssue(projectId: string, title: string, description: string): Promise<string> {
     this.ensureConnected();
 
     const result = await this.client.callTool({
-      name: "create_task",
+      name: "create_issue",
       arguments: {
         project_id: projectId,
         title,
@@ -212,50 +212,53 @@ export class VibeKanbanClient {
       },
     });
 
-    const parsed = this.parseToolResult<{ task_id: string } | null>(result, null);
-    if (!parsed?.task_id) {
-      throw new Error("タスクの作成に失敗しました");
+    const parsed = this.parseToolResult<{ id?: string; issue_id?: string } | null>(result, null);
+    const issueId = parsed?.id ?? parsed?.issue_id;
+    if (!issueId) {
+      throw new Error("イシューの作成に失敗しました");
     }
-    return parsed.task_id;
+    return issueId;
   }
 
   /**
-   * タスクを更新
+   * イシューを更新
    */
-  async updateTask(taskId: string, status: "todo" | "inprogress" | "done"): Promise<void> {
+  async updateIssue(issueId: string, status: string): Promise<void> {
     this.ensureConnected();
 
     await this.client.callTool({
-      name: "update_task",
+      name: "update_issue",
       arguments: {
-        task_id: taskId,
+        issue_id: issueId,
         status,
       },
     });
   }
 
   /**
-   * タスク実行を開始
+   * ワークスペースセッションを開始
    */
-  async startTaskAttempt(
-    taskId: string,
+  async startWorkspaceSession(
+    issueId: string | undefined,
+    title: string,
     executor: "CLAUDE_CODE",
     repos: Array<{ repo_id: string; base_branch: string }>
   ): Promise<VibeKanbanAttempt> {
     this.ensureConnected();
 
+    const args: Record<string, unknown> = { title, executor, repos };
+    if (issueId) {
+      args.issue_id = issueId;
+    }
+
     const result = await this.client.callTool({
       name: "start_workspace_session",
-      arguments: {
-        task_id: taskId,
-        executor,
-        repos,
-      },
+      arguments: args,
     });
 
     const attempt = this.parseToolResult<VibeKanbanAttempt | null>(result, null);
     if (!attempt) {
-      throw new Error("タスク実行の開始に失敗しました");
+      throw new Error("ワークスペースセッションの開始に失敗しました");
     }
     return attempt;
   }


### PR DESCRIPTION
## Summary
- vibe-kanban MCP APIの破壊的変更に追従
- `pnpm task:loop` コマンドが動作するように修正

## 変更内容

| 旧API | 新API | 変更内容 |
|-------|-------|---------|
| `list_tasks(project_id)` | `list_issues(project_id?)` | 名前変更、project_id オプショナル化 |
| `get_task(task_id)` | `get_issue(issue_id)` | 名前・パラメータ名変更 |
| `create_task(...)` | `create_issue(...)` | 名前変更 |
| `update_task(task_id, status)` | `update_issue(issue_id, status)` | 名前変更、ステータス値も変更 |
| `list_repos(project_id)` | `list_repos()` | パラメータ削除 |
| `startTaskAttempt(task_id, ...)` | `startWorkspaceSession(issue_id, title, ...)` | 名前変更、title引数追加 |

## 修正ファイル
- `packages/cli/src/commands/task-loop/lib/types.ts`
- `packages/cli/src/commands/task-loop/lib/vibe-kanban-client.ts`
- `packages/cli/src/commands/task-loop/index.ts`
- `packages/cli/package.json` (v0.1.26)

## Test plan
- [ ] `pnpm --filter @einja/dev-cli typecheck` 成功
- [ ] `pnpm --filter @einja/dev-cli build` 成功
- [ ] `pnpm task:loop` でMCP接続・タスク操作が動作すること