### PR TITLE
fix: vibe-kanban MCP の organization API 対応

### DIFF
--- a/packages/cli/src/commands/task-loop/lib/project-selector.ts
+++ b/packages/cli/src/commands/task-loop/lib/project-selector.ts
@@ -7,6 +7,7 @@
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import { type Interface, createInterface } from "node:readline";
+import type { VibeKanbanOrganization } from "./types.js";
 import type { VibeKanbanClient } from "./vibe-kanban-client.js";
 import { VibeKanbanRestClient } from "./vibe-kanban-rest-client.js";
 
@@ -94,17 +95,43 @@ export async function selectProject(
   vibeKanban: VibeKanbanClient,
   issueNumber?: number
 ): Promise<string> {
-  // 1. プロジェクト一覧を取得（接続確認も兼ねる）
-  let projects: Array<{ id: string; name: string }>;
+  // 1. 組織一覧を取得（接続確認も兼ねる）
+  let organizations: VibeKanbanOrganization[];
   try {
-    projects = await vibeKanban.listProjects();
+    organizations = await vibeKanban.listOrganizations();
   } catch (error) {
     // MCP経由でバックエンドに接続できない場合
     showCreateProjectGuidance(issueNumber);
     process.exit(1);
   }
 
-  // 2. 設定ファイルがあれば使用
+  if (organizations.length === 0) {
+    console.error("❌ 利用可能な組織がありません");
+    process.exit(1);
+  }
+
+  // 2. 組織を選択（1つなら自動選択）
+  let organizationId: string;
+  if (organizations.length === 1) {
+    organizationId = organizations[0].id;
+    console.log(`📂 組織: ${organizations[0].name}`);
+  } else {
+    // 複数の場合は最初の組織を自動選択
+    organizationId = organizations[0].id;
+    console.log(`⚠️  複数の組織が存在します（${organizations.length}件）`);
+    console.log(`📂 組織: ${organizations[0].name} (最初の組織を自動選択)`);
+  }
+
+  // 3. プロジェクト一覧を取得
+  let projects: Array<{ id: string; name: string }>;
+  try {
+    projects = await vibeKanban.listProjects(organizationId);
+  } catch (error) {
+    showCreateProjectGuidance(issueNumber);
+    process.exit(1);
+  }
+
+  // 4. 設定ファイルがあれば使用
   const config = loadConfig();
   if (config?.project_id) {
     // プロジェクトが存在するか確認
@@ -119,7 +146,7 @@ export async function selectProject(
     console.log("   プロジェクトを再選択してください\n");
   }
 
-  // 3. インタラクティブ選択
+  // 5. インタラクティブ選択
   const rl = createInterface({
     input: process.stdin,
     output: process.stdout,

--- a/packages/cli/src/commands/task-loop/lib/types.ts
+++ b/packages/cli/src/commands/task-loop/lib/types.ts
@@ -60,6 +60,12 @@ export interface RepoInfo {
   defaultBranch: string;
 }
 
+/** Vibe-Kanban 組織 */
+export interface VibeKanbanOrganization {
+  id: string;
+  name: string;
+}
+
 /** Vibe-Kanban プロジェクト */
 export interface VibeKanbanProject {
   id: string;

--- a/packages/cli/src/commands/task-loop/lib/vibe-kanban-client.ts
+++ b/packages/cli/src/commands/task-loop/lib/vibe-kanban-client.ts
@@ -12,6 +12,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type {
   VibeKanbanAttempt,
+  VibeKanbanOrganization,
   VibeKanbanProject,
   VibeKanbanRepo,
   VibeKanbanTask,
@@ -136,16 +137,31 @@ export class VibeKanbanClient {
   }
 
   /**
+   * 組織一覧を取得
+   */
+  async listOrganizations(): Promise<VibeKanbanOrganization[]> {
+    this.ensureConnected();
+
+    const result = await this.client.callTool({
+      name: "list_organizations",
+      arguments: {},
+    });
+
+    return this.parseToolResult<VibeKanbanOrganization[]>(result, []);
+  }
+
+  /**
    * プロジェクト一覧を取得
    */
-  async listProjects(): Promise<VibeKanbanProject[]> {
+  async listProjects(organizationId: string): Promise<VibeKanbanProject[]> {
     this.ensureConnected();
 
     const result = await this.client.callTool({
       name: "list_projects",
-      arguments: {},
+      arguments: { organization_id: organizationId },
     });
 
+    // APIレスポンスは { projects: [...] } 形式でラップされている
     const parsed = this.parseToolResult<{ projects: VibeKanbanProject[] }>(result, {
       projects: [],
     });


### PR DESCRIPTION
## Summary
- vibe-kanban MCP の破壊的変更に対応
- `list_projects` API が `organization_id` パラメータを必須として要求するようになったため対応

## Changes
- `VibeKanbanOrganization` 型を追加
- `listOrganizations()` メソッドを追加
- `listProjects(organizationId)` にパラメータ追加
- `selectProject()` で組織取得→プロジェクト取得のフローに変更
- 複数組織時の警告メッセージを追加

## Test plan
- [x] TypeScript 型チェック成功
- [x] ビルド成功
- [ ] `pnpm task:loop <issue-number>` で動作確認