### PR TITLE
fix(cli): task:loop の実行コマンド形式を変更

### DIFF
--- a/packages/cli/src/commands/task-loop/lib/task-state-manager.ts
+++ b/packages/cli/src/commands/task-loop/lib/task-state-manager.ts
@@ -295,7 +295,7 @@ export function generateVibeKanbanDescription(taskGroup: TaskGroup, issueNumber:
 以下のコマンドを実行してタスクを開始してください：
 
 \`\`\`
-/task-exec #${issueNumber} ${taskGroup.id}
+claude "/einja:task-exec #${issueNumber} ${taskGroup.id}"
 \`\`\`
 
 ---


### PR DESCRIPTION
## Summary

- Vibe-Kanbanワークスペース起動時に表示される実行コマンドの形式を変更

## 変更内容

| Before | After |
|--------|-------|
| `/task-exec #22 1.2` | `claude "/einja:task-exec #22 1.2"` |

## Test plan

- [x] ビルド成功: `pnpm --filter @einja/dev-cli build`
- [x] 型チェック成功: `pnpm --filter @einja/dev-cli typecheck`