### PR TITLE
fix(cli): task:loopのDone検知を修正

### DIFF
--- a/packages/cli/src/commands/task-loop/index.ts
+++ b/packages/cli/src/commands/task-loop/index.ts
@@ -224,10 +224,10 @@ export async function taskLoopCommand(
   };
 
   const initialDoneTasks = existingTasks.filter(
-    (t) => t.status === "done" && isTaskForThisIssue(t)
+    (t) => t.status === "Done" && isTaskForThisIssue(t)
   );
   const initialInProgressTasks = existingTasks.filter(
-    (t) => (t.status === "inprogress" || t.status === "in-progress") && isTaskForThisIssue(t)
+    (t) => t.status === "In Progress" && isTaskForThisIssue(t)
   );
   console.log(`📊 起動時のタスク状態 (Issue #${issueNumber} 関連):`);
   console.log(
@@ -269,7 +269,7 @@ export async function taskLoopCommand(
 
     // 既存チェック（再開サポート: 同一タイトルの既存親Issueを検索）
     const existingParent = existingTasks.find(
-      (t) => t.title === parentTitle && t.status !== "cancelled"
+      (t) => t.title === parentTitle && t.status !== "Cancelled"
     );
 
     if (existingParent) {
@@ -315,8 +315,8 @@ export async function taskLoopCommand(
       const currentTasks = await vibeKanban.listTasks(projectId);
 
       // 対象Issueに関連するDoneタスクの件数のみ表示
-      const doneTasks = currentTasks.filter((t) => t.status === "done" && isTaskForThisIssue(t));
-      const totalDoneTasks = currentTasks.filter((t) => t.status === "done").length;
+      const doneTasks = currentTasks.filter((t) => t.status === "Done" && isTaskForThisIssue(t));
+      const totalDoneTasks = currentTasks.filter((t) => t.status === "Done").length;
       console.log(`   📊 Done: ${doneTasks.length}件 (対象Issue) / ${totalDoneTasks}件 (全体)`);
 
       // 親Issueを除外してサブIssueのみDone検知（リスク#3 対策: IDベース）
@@ -490,7 +490,7 @@ async function waitForParentIssueDone(
 
   while (Date.now() - start < PARENT_DONE_TIMEOUT_MS) {
     const issue = await vibeKanban.getTask(parentIssueId);
-    if (issue?.status === "done") {
+    if (issue?.status === "Done") {
       console.log(`   ✅ 親Issue Done確認: Phase ${phaseNumber}`);
       return;
     }
@@ -500,7 +500,7 @@ async function waitForParentIssueDone(
   // タイムアウト: 手動でDoneに更新
   console.warn(`   ⚠️ 親Issue Phase ${phaseNumber} の自動Done検知がタイムアウト。手動更新します。`);
   try {
-    await vibeKanban.updateTask(parentIssueId, "done");
+    await vibeKanban.updateTask(parentIssueId, "Done");
     console.log(`   ✅ 親Issue 手動Done完了: Phase ${phaseNumber}`);
   } catch (error) {
     console.error(`   ❌ 親Issue Done更新失敗: Phase ${phaseNumber}`, error);
@@ -532,14 +532,14 @@ async function startExecutableTasks(
 
   console.log(`   📝 着手可能なタスク: ${executableGroups.length} 件`);
 
-  // 既存の Vibe-Kanban タスクを取得（cancelled 以外）
+  // 既存の Vibe-Kanban タスクを取得（Cancelled 以外）
   const existingTasks = await vibeKanban.listTasks(projectId);
 
   // 対象Issueに属する既存タスクのタスクグループIDを収集
   const existingTaskGroupIdsForThisIssue = new Set<string>();
   const issuePatternInDesc = `GitHub Issue #${issueNumber}`;
   for (const task of existingTasks) {
-    if (task.status === "cancelled") {
+    if (task.status === "Cancelled") {
       continue;
     }
     const taskGroupId = extractTaskGroupIdFromTitle(task.title);
@@ -599,8 +599,8 @@ async function startExecutableTasks(
     // マッピング登録
     stateManager.registerTaskMapping(taskId, taskGroup.id);
 
-    // ステータスを inprogress に更新
-    await vibeKanban.updateTask(taskId, "inprogress");
+    // ステータスを In Progress に更新
+    await vibeKanban.updateTask(taskId, "In Progress");
 
     // タスク実行開始（Phase ブランチをベースに使用）
     const phaseBranch = getPhaseBranchNameNew(issueNumber, taskGroup.phaseNumber);
@@ -652,7 +652,7 @@ async function syncExistingDoneTasks(
   descriptionCache: Map<string, string | null>
 ): Promise<ParsedIssue> {
   // Vibe-KanbanでDone状態のタスクを取得
-  const doneTasks = existingTasks.filter((t) => t.status === "done");
+  const doneTasks = existingTasks.filter((t) => t.status === "Done");
 
   // GitHub Issueで未完了のタスクグループIDを取得
   const { getCompletedTaskGroupIds } = await import("./lib/issue-parser.js");

--- a/packages/cli/src/commands/task-loop/lib/task-state-manager.test.ts
+++ b/packages/cli/src/commands/task-loop/lib/task-state-manager.test.ts
@@ -78,9 +78,9 @@ describe("TaskStateManager", () => {
     it("Done状態のタスク一覧でpreviousDoneTaskIdsが設定される", () => {
       // Given: Done状態のタスクが2つ、他ステータスが1つ存在
       const tasks: VibeKanbanTask[] = [
-        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "done" },
-        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "done" },
-        { id: "task-3", title: "[Issue22 1.3] Task 3", status: "todo" },
+        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "Done" },
+        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "Done" },
+        { id: "task-3", title: "[Issue22 1.3] Task 3", status: "Todo" },
       ];
 
       // When: 初期化を実行
@@ -102,7 +102,7 @@ describe("TaskStateManager", () => {
       // Then: 空のSetが設定される
       // 検証: 後続で完了タスクを検出すると新規として扱われる
       const newTasks: VibeKanbanTask[] = [
-        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "done" },
+        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "Done" },
       ];
       const newlyCompleted = manager.detectNewlyCompletedTasks(newTasks);
       expect(newlyCompleted).toEqual(["task-1"]);
@@ -111,8 +111,8 @@ describe("TaskStateManager", () => {
     it("Issue番号を指定すると、該当Issueのタスクのみログ出力される", () => {
       // Given: Issue22とIssue23のタスクが混在
       const tasks: VibeKanbanTask[] = [
-        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "done" },
-        { id: "task-2", title: "[Issue23 1.1] Task 2", status: "done" },
+        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "Done" },
+        { id: "task-2", title: "[Issue23 1.1] Task 2", status: "Done" },
       ];
 
       // When: Issue22を指定して初期化
@@ -127,9 +127,9 @@ describe("TaskStateManager", () => {
     it("descriptionCacheからIssue番号を推論できる", () => {
       // Given: タイトルにIssue番号がない旧形式のタスクで、descriptionCacheにIssue情報が含まれる
       const tasks: VibeKanbanTask[] = [
-        { id: "task-1", title: "[1.1] Task 1", status: "done" },
-        { id: "task-2", title: "[1.2] Task 2", status: "done" },
-        { id: "task-3", title: "[2.1] Task 3", status: "todo" },
+        { id: "task-1", title: "[1.1] Task 1", status: "Done" },
+        { id: "task-2", title: "[1.2] Task 2", status: "Done" },
+        { id: "task-3", title: "[2.1] Task 3", status: "Todo" },
       ];
 
       // descriptionCache: task-1とtask-2がIssue22に属する
@@ -152,8 +152,8 @@ describe("TaskStateManager", () => {
     it("タイトルに[IssueXX]がない旧形式でも動作する", () => {
       // Given: 旧形式のタスクタイトル（Issue番号なし）
       const tasks: VibeKanbanTask[] = [
-        { id: "task-old-1", title: "[1.1] レガシータスク1", status: "done" },
-        { id: "task-old-2", title: "[1.2] レガシータスク2", status: "done" },
+        { id: "task-old-1", title: "[1.1] レガシータスク1", status: "Done" },
+        { id: "task-old-2", title: "[1.2] レガシータスク2", status: "Done" },
       ];
 
       // descriptionCache: 旧形式タスクのIssue情報
@@ -176,8 +176,8 @@ describe("TaskStateManager", () => {
     it("descriptionCacheがnullの場合でも正常動作する", () => {
       // Given: descriptionがnullのタスク
       const tasks: VibeKanbanTask[] = [
-        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "done" },
-        { id: "task-2", title: "[1.2] Task 2 (旧形式)", status: "done" },
+        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "Done" },
+        { id: "task-2", title: "[1.2] Task 2 (旧形式)", status: "Done" },
       ];
 
       const descriptionCache = new Map<string, string | null>([
@@ -199,9 +199,9 @@ describe("TaskStateManager", () => {
     it("新形式と旧形式が混在している場合、両方を正しく認識する", () => {
       // Given: 新形式と旧形式のタスクが混在
       const tasks: VibeKanbanTask[] = [
-        { id: "task-new", title: "[Issue22 1.1] 新形式タスク", status: "done" },
-        { id: "task-old", title: "[1.2] 旧形式タスク", status: "done" },
-        { id: "task-other", title: "[Issue99 2.1] 別Issueのタスク", status: "done" },
+        { id: "task-new", title: "[Issue22 1.1] 新形式タスク", status: "Done" },
+        { id: "task-old", title: "[1.2] 旧形式タスク", status: "Done" },
+        { id: "task-other", title: "[Issue99 2.1] 別Issueのタスク", status: "Done" },
       ];
 
       const descriptionCache = new Map<string, string | null>([
@@ -226,15 +226,15 @@ describe("TaskStateManager", () => {
     it("前回より1タスク増加した場合、新規完了タスクIDを返す", () => {
       // Given: 初期状態で1つのタスクがDone
       const initialTasks: VibeKanbanTask[] = [
-        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "done" },
-        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "todo" },
+        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "Done" },
+        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "Todo" },
       ];
       manager.initializeDoneTaskIds(initialTasks);
 
       // When: task-2が完了した状態のタスク一覧
       const updatedTasks: VibeKanbanTask[] = [
-        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "done" },
-        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "done" },
+        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "Done" },
+        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "Done" },
       ];
 
       // Then: task-2が新規完了タスクとして検出される
@@ -245,8 +245,8 @@ describe("TaskStateManager", () => {
     it("変化なしの場合、空配列を返す", () => {
       // Given: 初期状態で1つのタスクがDone
       const tasks: VibeKanbanTask[] = [
-        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "done" },
-        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "todo" },
+        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "Done" },
+        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "Todo" },
       ];
       manager.initializeDoneTaskIds(tasks);
 
@@ -260,17 +260,17 @@ describe("TaskStateManager", () => {
     it("複数タスク同時完了の場合、全IDを返す", () => {
       // Given: 初期状態で全タスクがTodo
       const initialTasks: VibeKanbanTask[] = [
-        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "todo" },
-        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "todo" },
-        { id: "task-3", title: "[Issue22 1.3] Task 3", status: "todo" },
+        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "Todo" },
+        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "Todo" },
+        { id: "task-3", title: "[Issue22 1.3] Task 3", status: "Todo" },
       ];
       manager.initializeDoneTaskIds(initialTasks);
 
       // When: 3つのタスクが同時に完了
       const updatedTasks: VibeKanbanTask[] = [
-        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "done" },
-        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "done" },
-        { id: "task-3", title: "[Issue22 1.3] Task 3", status: "done" },
+        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "Done" },
+        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "Done" },
+        { id: "task-3", title: "[Issue22 1.3] Task 3", status: "Done" },
       ];
 
       // Then: 3つ全てが新規完了として検出される
@@ -281,15 +281,15 @@ describe("TaskStateManager", () => {
     it("Done状態が減少した場合（キャンセルなど）、previousDoneTaskIdsが正しく更新される", () => {
       // Given: 初期状態で2つのタスクがDone
       const initialTasks: VibeKanbanTask[] = [
-        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "done" },
-        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "done" },
+        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "Done" },
+        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "Done" },
       ];
       manager.initializeDoneTaskIds(initialTasks);
 
       // When: task-2がTodoに戻された状態
       const updatedTasks: VibeKanbanTask[] = [
-        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "done" },
-        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "todo" },
+        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "Done" },
+        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "Todo" },
       ];
       const result = manager.detectNewlyCompletedTasks(updatedTasks);
 
@@ -298,8 +298,8 @@ describe("TaskStateManager", () => {
 
       // Then: 次回task-2が完了すると新規完了として検出される
       const recompletedTasks: VibeKanbanTask[] = [
-        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "done" },
-        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "done" },
+        { id: "task-1", title: "[Issue22 1.1] Task 1", status: "Done" },
+        { id: "task-2", title: "[Issue22 1.2] Task 2", status: "Done" },
       ];
       const newResult = manager.detectNewlyCompletedTasks(recompletedTasks);
       expect(newResult).toEqual(["task-2"]);

--- a/packages/cli/src/commands/task-loop/lib/task-state-manager.ts
+++ b/packages/cli/src/commands/task-loop/lib/task-state-manager.ts
@@ -100,7 +100,7 @@ export class TaskStateManager {
 
     // フィルタリング適用（対象Issue番号がある場合のみ）
     const doneTasks = tasks
-      .filter((t) => t.status === "done")
+      .filter((t) => t.status === "Done")
       .filter((t) => this.isTaskForTargetIssue(t, descriptionCache));
 
     this.previousDoneTaskIds = new Set(doneTasks.map((t) => t.id));
@@ -132,7 +132,7 @@ export class TaskStateManager {
     );
 
     const currentDoneIds = new Set(
-      relevantTasks.filter((t) => t.status === "done").map((t) => t.id)
+      relevantTasks.filter((t) => t.status === "Done").map((t) => t.id)
     );
 
     // デバッグ: 比較情報を出力

--- a/packages/cli/src/commands/task-loop/lib/types.ts
+++ b/packages/cli/src/commands/task-loop/lib/types.ts
@@ -78,7 +78,7 @@ export interface VibeKanbanTask {
   id: string;
   title: string;
   description?: string;
-  status: "todo" | "inprogress" | "in-progress" | "done" | "cancelled";
+  status: "Backlog" | "Todo" | "In Progress" | "Done" | "Cancelled";
   parent_issue_id?: string;
 }
 

--- a/packages/cli/src/commands/task-loop/lib/vibe-kanban-client.test.ts
+++ b/packages/cli/src/commands/task-loop/lib/vibe-kanban-client.test.ts
@@ -190,14 +190,14 @@ describe("VibeKanbanClient", () => {
         });
 
         // When: updateTask メソッドを呼び出す
-        await client.updateTask("issue-001", "done");
+        await client.updateTask("issue-001", "Done");
 
         // Then: update_issue ツールが issue_id パラメータで呼び出される
         expect(mockMCPClient.callTool).toHaveBeenCalledWith({
           name: "update_issue",
           arguments: {
             issue_id: "issue-001",
-            status: "done",
+            status: "Done",
           },
         });
       });
@@ -216,7 +216,7 @@ describe("VibeKanbanClient", () => {
         });
 
         // When: updateTask メソッドを呼び出す
-        await client.updateTask("issue-001", "inprogress");
+        await client.updateTask("issue-001", "In Progress");
 
         // Then: task_id ではなく issue_id が使用される
         const callArgs = mockMCPClient.callTool.mock.calls[0][0];
@@ -314,7 +314,7 @@ describe("VibeKanbanClient", () => {
 
   describe("ステータス値統一", () => {
     describe("updateTask", () => {
-      it("inprogress を指定すると、MCP には in-progress として送信される", async () => {
+      it("In Progress を指定すると、MCP にそのまま送信される", async () => {
         // Given: Vibe-Kanban MCPが接続済み
         await client.connect();
 
@@ -322,20 +322,20 @@ describe("VibeKanbanClient", () => {
           content: [{ type: "text", text: JSON.stringify({ success: true }) }],
         });
 
-        // When: inprogress を指定してタスクを更新
-        await client.updateTask("issue-001", "inprogress");
+        // When: In Progress を指定してタスクを更新
+        await client.updateTask("issue-001", "In Progress");
 
-        // Then: MCP には in-progress として送信される
+        // Then: MCP にそのまま送信される
         expect(mockMCPClient.callTool).toHaveBeenCalledWith({
           name: "update_issue",
           arguments: {
             issue_id: "issue-001",
-            status: "in-progress",
+            status: "In Progress",
           },
         });
       });
 
-      it("todo や done は変換されずにそのまま送信される", async () => {
+      it("Todo や Done はそのまま送信される", async () => {
         // Given: Vibe-Kanban MCPが接続済み
         await client.connect();
 
@@ -343,25 +343,25 @@ describe("VibeKanbanClient", () => {
           content: [{ type: "text", text: JSON.stringify({ success: true }) }],
         });
 
-        // When: todo と done を送信
-        await client.updateTask("issue-001", "todo");
-        await client.updateTask("issue-002", "done");
+        // When: Todo と Done を送信
+        await client.updateTask("issue-001", "Todo");
+        await client.updateTask("issue-002", "Done");
 
-        // Then: 変換されずにそのまま送信される
+        // Then: そのまま送信される
         expect(mockMCPClient.callTool).toHaveBeenCalledWith({
           name: "update_issue",
-          arguments: { issue_id: "issue-001", status: "todo" },
+          arguments: { issue_id: "issue-001", status: "Todo" },
         });
         expect(mockMCPClient.callTool).toHaveBeenCalledWith({
           name: "update_issue",
-          arguments: { issue_id: "issue-002", status: "done" },
+          arguments: { issue_id: "issue-002", status: "Done" },
         });
       });
     });
 
     describe("getTask", () => {
-      it("MCP から in-progress を受信すると、内部では inprogress として扱う", async () => {
-        // Given: MCP が in-progress ステータスのタスクを返す
+      it("MCP から In Progress を受信すると、そのまま返される", async () => {
+        // Given: MCP が In Progress ステータスのタスクを返す
         await client.connect();
 
         mockMCPClient.callTool.mockResolvedValueOnce({
@@ -371,7 +371,7 @@ describe("VibeKanbanClient", () => {
               text: JSON.stringify({
                 id: "issue-001",
                 title: "Test",
-                status: "in-progress",
+                status: "In Progress",
               }),
             },
           ],
@@ -380,14 +380,14 @@ describe("VibeKanbanClient", () => {
         // When: getTask を呼び出す
         const task = await client.getTask("issue-001");
 
-        // Then: 内部では inprogress として扱う
-        expect(task?.status).toBe("inprogress");
+        // Then: そのまま返される
+        expect(task?.status).toBe("In Progress");
       });
     });
 
     describe("listTasks", () => {
-      it("MCP から in-progress を受信すると、各タスクで inprogress に変換される", async () => {
-        // Given: MCP が in-progress ステータスのタスクを含む一覧を返す
+      it("MCP から受信したステータス値がそのまま返される", async () => {
+        // Given: MCP が各種ステータスのタスクを含む一覧を返す
         await client.connect();
 
         mockMCPClient.callTool.mockResolvedValueOnce({
@@ -396,9 +396,9 @@ describe("VibeKanbanClient", () => {
               type: "text",
               text: JSON.stringify({
                 issues: [
-                  { id: "1", title: "Task 1", status: "todo" },
-                  { id: "2", title: "Task 2", status: "in-progress" },
-                  { id: "3", title: "Task 3", status: "done" },
+                  { id: "1", title: "Task 1", status: "Todo" },
+                  { id: "2", title: "Task 2", status: "In Progress" },
+                  { id: "3", title: "Task 3", status: "Done" },
                 ],
               }),
             },
@@ -408,10 +408,10 @@ describe("VibeKanbanClient", () => {
         // When: listTasks を呼び出す
         const tasks = await client.listTasks("project-123");
 
-        // Then: in-progress が inprogress に変換される
-        expect(tasks[0].status).toBe("todo");
-        expect(tasks[1].status).toBe("inprogress");
-        expect(tasks[2].status).toBe("done");
+        // Then: そのまま返される
+        expect(tasks[0].status).toBe("Todo");
+        expect(tasks[1].status).toBe("In Progress");
+        expect(tasks[2].status).toBe("Done");
       });
     });
   });

--- a/packages/cli/src/commands/task-loop/lib/vibe-kanban-client.ts
+++ b/packages/cli/src/commands/task-loop/lib/vibe-kanban-client.ts
@@ -259,17 +259,17 @@ export class VibeKanbanClient {
    * 内部で update_issue ツールを呼び出す（旧API: update_task → 新API: update_issue）
    * パラメータ名も変更（task_id → issue_id）
    */
-  async updateTask(taskId: string, status: "todo" | "inprogress" | "done"): Promise<void> {
+  async updateTask(
+    taskId: string,
+    status: "Backlog" | "Todo" | "In Progress" | "Done" | "Cancelled"
+  ): Promise<void> {
     this.ensureConnected();
-
-    // 送信前にステータス値を変換
-    const mappedStatus = this.normalizeStatusForSend(status);
 
     await this.client.callTool({
       name: "update_issue",
       arguments: {
         issue_id: taskId,
-        status: mappedStatus,
+        status,
       },
     });
   }
@@ -383,19 +383,17 @@ export class VibeKanbanClient {
   }
 
   /**
-   * ステータス値をMCP送信用に変換
-   * 内部形式 "inprogress" → MCP形式 "in-progress"
+   * ステータス値をMCP送信用に変換（現在は変換不要、将来の拡張用に保持）
    */
   private normalizeStatusForSend(status: string): string {
-    return status === "inprogress" ? "in-progress" : status;
+    return status;
   }
 
   /**
-   * ステータス値を内部形式に変換
-   * MCP形式 "in-progress" → 内部形式 "inprogress"
+   * ステータス値を内部形式に変換（現在は変換不要、将来の拡張用に保持）
    */
   private normalizeStatusForReceive(status: string): string {
-    return status === "in-progress" ? "inprogress" : status;
+    return status;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Vibe-Kanban APIが返すstatus値が`"Done"`（大文字D）なのに、コード側で`"done"`（小文字d）と比較していたため、Done検知が動作していなかった問題を修正
- `types.ts`のVibeKanbanTaskのstatus型を実際のAPI値（`"Backlog" | "Todo" | "In Progress" | "Done" | "Cancelled"`）に合わせて更新
- 関連するすべてのファイルのstatus比較を修正

## Test plan
- [x] `pnpm --filter @einja/dev-cli typecheck` が成功すること
- [ ] `pnpm task:loop`を実行し、Done検知が正しく動作すること