### PR TITLE
fix(cli): createTaskにparent_issue_idパラメータを追加

### DIFF
--- a/packages/cli/src/commands/task-loop/index.ts
+++ b/packages/cli/src/commands/task-loop/index.ts
@@ -38,7 +38,6 @@ import {
 } from "./lib/task-state-manager.js";
 import type { ParsedIssue, VibeKanbanRepo } from "./lib/types.js";
 import { VibeKanbanClient } from "./lib/vibe-kanban-client.js";
-import { VibeKanbanRestClient } from "./lib/vibe-kanban-rest-client.js";
 import { getWorktreePathByAttemptId, runDirenvAllow } from "./lib/worktree-utils.js";
 
 export interface TaskLoopOptions {
@@ -172,24 +171,6 @@ export async function taskLoopCommand(
   // プロジェクト ID 取得（設定ファイルまたはインタラクティブ選択）
   const projectId = await selectProject(vibeKanban, issueNumber);
 
-  // REST APIクライアント初期化（サブIssue作成に必要）
-  const restPort = VibeKanbanRestClient.discoverPort();
-  if (!restPort) {
-    console.error("❌ Vibe-Kanban REST API のポートが見つかりません");
-    process.exit(1);
-  }
-  const restClient = new VibeKanbanRestClient(restPort);
-
-  // REST API Capability Probe
-  const restAvailable = await restClient.probeCapability();
-  if (!restAvailable) {
-    console.warn(
-      "⚠️ Vibe-Kanban REST API (/api/remote/issues) が利用できません。サブIssue機能が制限されます。"
-    );
-  } else {
-    console.log("✅ Vibe-Kanban REST API 利用可能");
-  }
-
   // タスク状態マネージャー初期化
   const stateManager = new TaskStateManager();
 
@@ -301,7 +282,6 @@ export async function taskLoopCommand(
       projectId,
       vibeKanban,
       stateManager,
-      restClient,
       currentRepo
     );
 
@@ -361,7 +341,6 @@ export async function taskLoopCommand(
           projectId,
           vibeKanban,
           stateManager,
-          restClient,
           currentRepo
         );
       }
@@ -519,7 +498,6 @@ async function startExecutableTasks(
   projectId: string,
   vibeKanban: VibeKanbanClient,
   stateManager: TaskStateManager,
-  restClient: VibeKanbanRestClient,
   currentRepo: VibeKanbanRepo
 ): Promise<void> {
   // 着手可能なタスクグループを選定
@@ -592,8 +570,7 @@ async function startExecutableTasks(
       projectId,
       phaseMapping.parentIssueId,
       title,
-      description,
-      restClient
+      description
     );
 
     // マッピング登録

--- a/packages/cli/src/commands/task-loop/lib/vibe-kanban-client.test.ts
+++ b/packages/cli/src/commands/task-loop/lib/vibe-kanban-client.test.ts
@@ -173,6 +173,42 @@ describe("VibeKanbanClient", () => {
         // Then: issue_id が正しく取得される
         expect(result).toBe("new-issue-456");
       });
+
+      it("parentIssueId を渡すと、parent_issue_id が arguments に含まれる", async () => {
+        // Given: Vibe-Kanban MCPが接続済み
+        await client.connect();
+
+        mockMCPClient.callTool.mockResolvedValueOnce({
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({ issue_id: "sub-issue-789" }),
+            },
+          ],
+        });
+
+        // When: createTask メソッドを parentIssueId 付きで呼び出す
+        const result = await client.createTask(
+          "project-123",
+          "Sub Task",
+          "Sub Description",
+          "parent-issue-001"
+        );
+
+        // Then: create_issue ツールが parent_issue_id を含んで呼び出される
+        expect(mockMCPClient.callTool).toHaveBeenCalledWith({
+          name: "create_issue",
+          arguments: {
+            project_id: "project-123",
+            title: "Sub Task",
+            description: "Sub Description",
+            parent_issue_id: "parent-issue-001",
+          },
+        });
+
+        // Then: Issue IDが返る
+        expect(result).toBe("sub-issue-789");
+      });
     });
 
     describe("updateTask", () => {
@@ -474,7 +510,7 @@ describe("VibeKanbanClient", () => {
     });
 
     describe("createSubIssue", () => {
-      it("MCP create_issue 成功 + REST PATCH 成功の場合、サブIssue IDが返る", async () => {
+      it("parent_issue_id を含む create_issue が呼ばれ、サブIssue IDが返る", async () => {
         // Given: Vibe-Kanban MCPが接続済み
         await client.connect();
 
@@ -487,164 +523,27 @@ describe("VibeKanbanClient", () => {
           ],
         });
 
-        const mockRestClient = {
-          setParentIssue: vi.fn().mockResolvedValueOnce(undefined),
-        };
-
         // When: createSubIssue メソッドを呼び出す
         const result = await client.createSubIssue(
           "project-123",
           "parent-issue-001",
           "Sub Task",
-          "Sub Description",
-          mockRestClient
+          "Sub Description"
         );
 
-        // Then: create_issue ツールが呼び出される
+        // Then: create_issue ツールが parent_issue_id を含んで呼び出される
         expect(mockMCPClient.callTool).toHaveBeenCalledWith({
           name: "create_issue",
           arguments: {
             project_id: "project-123",
             title: "Sub Task",
             description: "Sub Description",
+            parent_issue_id: "parent-issue-001",
           },
         });
 
-        // Then: setParentIssue が正しい引数で呼ばれる
-        expect(mockRestClient.setParentIssue).toHaveBeenCalledWith("sub-issue-456", "parent-issue-001");
-
         // Then: サブIssue IDが返る
         expect(result).toBe("sub-issue-456");
-      });
-
-      it("REST PATCH が1回目失敗・2回目成功の場合、リトライして成功する", async () => {
-        // Given: Vibe-Kanban MCPが接続済み
-        await client.connect();
-
-        mockMCPClient.callTool.mockResolvedValueOnce({
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify({ issue_id: "sub-issue-789" }),
-            },
-          ],
-        });
-
-        // setTimeout をモックしてすぐ実行させる
-        const setTimeoutSpy = vi.spyOn(global, "setTimeout").mockImplementation(
-          (fn: TimerHandler) => {
-            if (typeof fn === "function") fn();
-            return 0 as unknown as ReturnType<typeof setTimeout>;
-          }
-        );
-
-        const mockRestClient = {
-          setParentIssue: vi
-            .fn()
-            .mockRejectedValueOnce(new Error("Network error"))
-            .mockResolvedValueOnce(undefined),
-        };
-
-        // When: createSubIssue メソッドを呼び出す
-        const result = await client.createSubIssue(
-          "project-123",
-          "parent-issue-001",
-          "Sub Task",
-          "Sub Description",
-          mockRestClient
-        );
-
-        // Then: setParentIssue が2回呼ばれる（1回失敗 + 1回成功）
-        expect(mockRestClient.setParentIssue).toHaveBeenCalledTimes(2);
-
-        // Then: サブIssue IDが返る
-        expect(result).toBe("sub-issue-789");
-
-        setTimeoutSpy.mockRestore();
-      });
-
-      it("REST PATCH が3回全て失敗した場合、deleteTask が呼ばれてからエラーがスローされる", async () => {
-        // Given: Vibe-Kanban MCPが接続済み
-        await client.connect();
-
-        // create_issue の成功レスポンス + delete_issue の成功レスポンス
-        mockMCPClient.callTool
-          .mockResolvedValueOnce({
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify({ issue_id: "sub-issue-fail" }),
-              },
-            ],
-          })
-          .mockResolvedValueOnce({
-            content: [{ type: "text", text: JSON.stringify({ success: true }) }],
-          });
-
-        // setTimeout をモックしてすぐ実行させる
-        const setTimeoutSpy = vi.spyOn(global, "setTimeout").mockImplementation(
-          (fn: TimerHandler) => {
-            if (typeof fn === "function") fn();
-            return 0 as unknown as ReturnType<typeof setTimeout>;
-          }
-        );
-
-        const mockRestClient = {
-          setParentIssue: vi.fn().mockRejectedValue(new Error("Persistent error")),
-        };
-
-        // When: createSubIssue メソッドを呼び出す
-        await expect(
-          client.createSubIssue(
-            "project-123",
-            "parent-issue-001",
-            "Sub Task",
-            "Sub Description",
-            mockRestClient
-          )
-        ).rejects.toThrow("サブIssueの作成に失敗しました");
-
-        // Then: setParentIssue が3回呼ばれる
-        expect(mockRestClient.setParentIssue).toHaveBeenCalledTimes(3);
-
-        // Then: delete_issue ツールが呼ばれる（deleteTask 経由）
-        expect(mockMCPClient.callTool).toHaveBeenCalledWith({
-          name: "delete_issue",
-          arguments: { issue_id: "sub-issue-fail" },
-        });
-
-        setTimeoutSpy.mockRestore();
-      });
-
-      it("restClient.setParentIssue が正しい引数（issueId, parentIssueId）で呼ばれる", async () => {
-        // Given: Vibe-Kanban MCPが接続済み
-        await client.connect();
-
-        mockMCPClient.callTool.mockResolvedValueOnce({
-          content: [
-            {
-              type: "text",
-              text: JSON.stringify({ issue_id: "sub-issue-999" }),
-            },
-          ],
-        });
-
-        const mockRestClient = {
-          setParentIssue: vi.fn().mockResolvedValueOnce(undefined),
-        };
-
-        // When: createSubIssue メソッドを呼び出す
-        await client.createSubIssue(
-          "project-abc",
-          "parent-issue-xyz",
-          "My Sub Task",
-          "Description",
-          mockRestClient
-        );
-
-        // Then: setParentIssue が issueId=作成されたID, parentIssueId=指定した親ID で呼ばれる
-        expect(mockRestClient.setParentIssue).toHaveBeenCalledWith("sub-issue-999", "parent-issue-xyz");
-        expect(mockRestClient.setParentIssue).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/packages/cli/src/commands/task-loop/lib/vibe-kanban-client.ts
+++ b/packages/cli/src/commands/task-loop/lib/vibe-kanban-client.ts
@@ -233,9 +233,18 @@ export class VibeKanbanClient {
   /**
    * タスクを作成
    * 内部で create_issue ツールを呼び出す（旧API: create_task → 新API: create_issue）
+   * @param projectId プロジェクトID
+   * @param title タイトル
+   * @param description 説明
+   * @param parentIssueId 親IssueのID（サブ課題を作成する場合）
    * @returns タスクID
    */
-  async createTask(projectId: string, title: string, description: string): Promise<string> {
+  async createTask(
+    projectId: string,
+    title: string,
+    description: string,
+    parentIssueId?: string
+  ): Promise<string> {
     this.ensureConnected();
 
     const result = await this.client.callTool({
@@ -244,6 +253,7 @@ export class VibeKanbanClient {
         project_id: projectId,
         title,
         description,
+        ...(parentIssueId && { parent_issue_id: parentIssueId }),
       },
     });
 
@@ -285,57 +295,23 @@ export class VibeKanbanClient {
 
   /**
    * サブIssueを作成（タスクグループ対応）
-   * B案: MCP create_issue + REST PATCH parent_issue_id
+   * MCP create_issue に parent_issue_id を直接指定
    *
    * @param projectId プロジェクトID
    * @param parentIssueId 親IssueのID
    * @param title タイトル
    * @param description 説明
-   * @param restClient REST APIクライアント（PATCH用）
    * @returns サブIssue ID
    */
   async createSubIssue(
     projectId: string,
     parentIssueId: string,
     title: string,
-    description: string,
-    restClient: { setParentIssue: (issueId: string, parentIssueId: string) => Promise<void> }
+    description: string
   ): Promise<string> {
-    // Step 1: MCP create_issue で通常Issue作成
-    const issueId = await this.createTask(projectId, title, description);
-
-    // Step 2: REST PATCH で parent_issue_id 設定（リトライ3回）
-    const MAX_RETRIES = 3;
-    let lastError: Error | null = null;
-
-    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-      try {
-        await restClient.setParentIssue(issueId, parentIssueId);
-        console.log(`   ✅ サブIssue作成完了: ${issueId} (parent: ${parentIssueId})`);
-        return issueId;
-      } catch (error) {
-        lastError = error instanceof Error ? error : new Error(String(error));
-        console.warn(
-          `   ⚠️ parent_issue_id 設定失敗 (${attempt}/${MAX_RETRIES}): ${lastError.message}`
-        );
-        if (attempt < MAX_RETRIES) {
-          // 指数バックオフ: 1秒, 2秒, 4秒
-          await new Promise((resolve) => setTimeout(resolve, 1000 * Math.pow(2, attempt - 1)));
-        }
-      }
-    }
-
-    // 全リトライ失敗: Issue を削除して再試行
-    console.error(`   ❌ parent_issue_id の設定に${MAX_RETRIES}回失敗。Issueを削除して再作成します。`);
-    try {
-      await this.deleteTask(issueId);
-    } catch (deleteError) {
-      console.warn(`   ⚠️ Issue削除失敗: ${deleteError}`);
-    }
-
-    throw new Error(
-      `サブIssueの作成に失敗しました（parent_issue_id設定失敗）: ${lastError?.message}`
-    );
+    const issueId = await this.createTask(projectId, title, description, parentIssueId);
+    console.log(`   ✅ サブIssue作成完了: ${issueId} (parent: ${parentIssueId})`);
+    return issueId;
   }
 
   /**


### PR DESCRIPTION
## Summary

- `createTask`メソッドにオプションの`parentIssueId`パラメータを追加
- MCP `create_issue`に`parent_issue_id`を直接渡すように変更
- `createSubIssue`をシンプル化（REST APIワークアラウンドを削除）
- `index.ts`から`VibeKanbanRestClient`の依存を完全削除
- テストを新しいAPI仕様に合わせて更新

サブIssueが親Issueに正しく紐づかない問題を修正します。

## Test plan

- [x] `pnpm --filter @einja/dev-cli test` - 全509件パス
- [x] `pnpm --filter @einja/dev-cli typecheck` - 成功
- [ ] 実際に`task:loop`を実行し、Phase X.1のサブIssueが親Issueに紐づくことを確認