### PR TITLE
feat: admin-ui 同期の実用化 (sync CLI拡張 + Skill 追加 + バグ修正)

### DIFF
--- a/.changeset/admin-ui-sync-detail-flag.md
+++ b/.changeset/admin-ui-sync-detail-flag.md
@@ -1,0 +1,11 @@
+---
+"@einja-inc/create-app": minor
+---
+
+Add `--apps-detail <apps>` and `--packages-detail <packages>` CLI flags to `sync` command for non-interactive subset selection (e.g. `sync --categories packages --packages-detail admin-ui --yes`). Fix bug where `--yes` did not suppress interactive prompts when used with `--categories`.
+
+- New: `--apps-detail <list>` and `--packages-detail <list>` CLI flags
+- New: `SyncOptions.appsDetail` / `SyncOptions.packagesDetail` fields
+- Fix: `detectProjectConfig` failure now triggers `process.exit(1)` in `--categories` mode (previously only in `--yes` mode)
+- Improved: Input sanitization for CSV list values (trim, drop empty)
+- Improved: Safe-name validation for `apps`/`packages` detail entries

--- a/.claude/skills/einja-admin-ui-sync/SKILL.md
+++ b/.claude/skills/einja-admin-ui-sync/SKILL.md
@@ -1,0 +1,432 @@
+---
+name: einja-admin-ui-sync
+description: "Syncs `packages/admin-ui` from the template repository to the current child project, with safety checks (template-repo detection, git status check, dry-run preview, conflict summary, backup). Use when admin-ui drift is suspected, when picking up upstream component updates, or when triggered by phrases like \"admin-ui を sync\", \"admin-ui 同期\", \"shadcn コンポーネント同期\". Do NOT use for: docs/einja sync (use `npx @einja-inc/dev-cli sync`), full template sync (use `npx @einja-inc/create-app sync` interactive), apps/* sync (use `npx @einja-inc/create-app sync --categories apps`)."
+user-invocable: true
+allowed-tools: Bash, AskUserQuestion, Read
+---
+
+<!-- 参考: packages/create-app の `sync --categories packages --packages-detail admin-ui --yes` 非対話モード（@einja-inc/create-app） -->
+<!-- ベース: .claude/skills/einja-task-commit/SKILL.md, .claude/skills/einja-conflict-resolver/SKILL.md -->
+
+# einja-admin-ui-sync Skill: admin-ui 同期エンジン
+
+## 役割
+
+子プロジェクトの `packages/admin-ui` を、テンプレート（`@einja-inc/create-app`）の最新内容へ非対話で sync します。安全装置として、テンプレ repo 自己実行ブロック、git status チェック、dry-run プレビュー、初回判定、結果サマリを実装します。
+
+## Sandbox 注意事項
+
+**すべての `git` / `npx` コマンドは `dangerouslyDisableSandbox: true` で実行すること。**
+sandbox 環境では npm cache 書き込みや git index 更新がブロックされるため、Bash tool 呼び出し時に必ずこのフラグを設定する。
+
+## 前提
+
+- 本 Skill は **`@einja-inc/create-app` v0.x（`sync --packages-detail` 対応版以降）が npm publish された後** にのみ有効。古いバージョンでは `--packages-detail` フラグ未対応で失敗する
+- 失敗時は `EINJA_CREATE_APP_VERSION=@latest` で再試行、または `npm view @einja-inc/create-app version` で対応バージョンを確認すること
+
+---
+
+## 実行手順（8 ステップ）
+
+### Step 1: テンプレ repo 自己実行ブロック
+
+子プロジェクト用 Skill のため、テンプレ repo（`einja-management-template`）内で実行されたらブロックする。
+
+#### 検出ロジック
+
+```bash
+TEMPLATE_DETECTED=false
+
+# 検出1: packages/create-app/ が存在
+if [ -d packages/create-app ]; then
+  TEMPLATE_DETECTED=true
+  echo "DETECTED: packages/create-app/ exists"
+fi
+
+# 検出2: package.json の name が einja-management-template
+# jq があれば優先、無ければ node にフォールバック（jq 未導入環境でも動作させる）
+if command -v jq &>/dev/null; then
+  PKG_NAME=$(cat package.json 2>/dev/null | jq -r .name 2>/dev/null)
+else
+  PKG_NAME=$(node -e "try { console.log(require(process.cwd() + '/package.json').name || '') } catch { console.log('') }" 2>/dev/null)
+fi
+
+if [ "$PKG_NAME" = "einja-management-template" ]; then
+  TEMPLATE_DETECTED=true
+  echo "DETECTED: package.json name == einja-management-template"
+fi
+
+echo "TEMPLATE_DETECTED=$TEMPLATE_DETECTED"
+```
+
+#### ブロック時の AskUserQuestion
+
+`TEMPLATE_DETECTED=true` の場合、以下を提示してデフォルト中断:
+
+```yaml
+AskUserQuestion:
+  question: |
+    テンプレートリポジトリ自体で admin-ui sync を実行しようとしています。
+    本 Skill は子プロジェクトでの sync 用です。原本（packages/admin-ui）を sync 経由で上書きすると差分管理が破綻する恐れがあります。
+
+    検出された理由:
+    - {検出条件1 / 検出条件2}
+  header: "テンプレ repo 検出"
+  options:
+    - label: "中断する（推奨）"
+      description: "Skill を終了する。Note: テンプレ repo では packages/admin-ui を直接編集すること。sync は子プロジェクト側で行う"
+    - label: "強制続行（非推奨）"
+      description: "検出を無視して以降のステップに進む。Note: 原本ファイルが上書きされる可能性あり。バックアップを取って自己責任で実行"
+    - label: "その他（自由入力）"
+      description: "上記以外の対応を伝える"
+```
+
+「中断」を選択 → 即座に終了。「強制続行」を選択 → Step 2 へ進む。
+
+---
+
+### Step 2: git status クリーン確認
+
+未コミット変更があると sync 結果が混ざってレビュー困難になるため確認する。
+
+```bash
+DIRTY=$(git status --porcelain | wc -l | tr -d ' ')
+if [ "$DIRTY" -gt 0 ]; then
+  echo "DIRTY=$DIRTY files"
+  git status --short
+fi
+```
+
+`DIRTY > 0` の場合、以下を提示してデフォルト中断:
+
+```yaml
+AskUserQuestion:
+  question: |
+    作業ツリーに未コミット変更が {DIRTY} 件あります。
+    sync 実行で差分が混ざるとレビューが困難になります。
+
+    {git status --short 出力}
+  header: "git status dirty"
+  options:
+    - label: "中断する（推奨）"
+      description: "Skill を終了し、先に既存変更をコミット or stash する。Note: 一番安全だが手動操作が必要"
+    - label: "stash して続行"
+      description: "git stash で退避してから sync を実行し、終了後に手動で stash pop する。Note: stash pop 時にコンフリクトする可能性あり"
+    - label: "dirty のまま続行（非推奨）"
+      description: "未コミット変更を残したまま sync を実行する。Note: 差分が混ざるためレビュー負荷が高い"
+    - label: "その他（自由入力）"
+      description: "上記以外の対応を伝える"
+```
+
+「stash して続行」を選んだ場合は `git stash push -m "pre-admin-ui-sync"` を実行し、Step 8 完了時に「stash pop してください」と案内する（自動 pop はコンフリクト時の中断ロジックが煩雑になるため、敢えて手動）。
+
+---
+
+### Step 3: 初回判定（`.einja-sync.json` 存在チェック）
+
+merge 戦略を切り替えるため、3-way merge の base メタが存在するかを判定する。
+
+```bash
+if [ -f .einja-sync.json ]; then
+  SYNC_MODE="existing"
+  echo "SYNC_MODE=existing (.einja-sync.json found)"
+else
+  SYNC_MODE="initial"
+  echo "SYNC_MODE=initial (first-time sync)"
+fi
+```
+
+- `SYNC_MODE=initial` → 初回経路（Step 7a）
+- `SYNC_MODE=existing` → 既存メタ経路（Step 7b）
+
+内部状態として保持する（後続ステップで参照）。
+
+---
+
+### Step 4: `@einja-inc/create-app` バージョン解決
+
+環境変数 `EINJA_CREATE_APP_VERSION` でバージョン固定 / ローカルビルド指定が可能。未設定なら `latest`。
+
+**セキュリティ**: 環境変数は直接シェル展開されるため、コマンドインジェクションを防ぐ目的で `latest` または semver のみを許可する。
+
+```bash
+VERSION="${EINJA_CREATE_APP_VERSION:-latest}"
+
+# semver または 'latest' のみ許可（コマンドインジェクション防止）
+if ! [[ "$VERSION" =~ ^(latest|[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?)$ ]]; then
+  echo "Invalid EINJA_CREATE_APP_VERSION: $VERSION" >&2
+  echo "  Allowed: 'latest' or semver (e.g. '1.2.3', '1.2.3-beta.1')" >&2
+  exit 1
+fi
+
+CREATE_APP_PKG="@einja-inc/create-app@${VERSION}"
+echo "Using: $CREATE_APP_PKG"
+```
+
+#### 利用例
+
+| 環境変数値 | 解決後 | 用途 |
+|----------|--------|------|
+| 未設定 | `@einja-inc/create-app@latest` | 通常運用 |
+| `0.3.31` | `@einja-inc/create-app@0.3.31` | バージョン固定 |
+| `latest` | `@einja-inc/create-app@latest` | 明示的に最新 |
+| `1.2.3-beta.1` | `@einja-inc/create-app@1.2.3-beta.1` | プレリリース指定 |
+| `file:./packages/create-app` | エラー（許可されない） | ローカルテストは `npm link` を使うこと |
+
+ローカルパッケージで動かしたい場合は、本 Skill 経由ではなく事前にユーザーが `npm link` した上で `npx create-app sync ...` 形式を直接利用する（本 Skill では未自動化）。
+
+---
+
+### Step 5: dry-run 実行
+
+実際の書き込み前に変更プレビューを取得する。
+
+```bash
+DRY_RUN_OUTPUT=$(npx -y "$CREATE_APP_PKG" sync \
+  --categories packages \
+  --packages-detail admin-ui \
+  --dry-run \
+  --yes 2>&1)
+
+echo "$DRY_RUN_OUTPUT"
+```
+
+- `-y` は npx 側の install 確認をスキップ（パッケージ自体の `--yes` と別物）
+- `--yes` は create-app の非対話モード
+- 出力は丸ごとキャプチャしてユーザーに表示
+
+失敗時（exit code != 0）:
+- `--packages-detail` 未対応バージョンの可能性 → 「`EINJA_CREATE_APP_VERSION` を `latest` 等で再指定してください」と案内
+- ネットワーク失敗 → `npm view @einja-inc/create-app version` で疎通確認を案内
+
+---
+
+### Step 6: 差分サマリ提示
+
+dry-run 出力から「同期対象: N 個のファイル」「同期プレビュー: ...」を抽出して整形提示する。
+
+```bash
+# 例: 同期対象ファイル数の抽出（出力フォーマットは create-app 側に依存）
+FILE_COUNT=$(echo "$DRY_RUN_OUTPUT" | grep -oE "同期対象: [0-9]+ 個" | grep -oE "[0-9]+" | head -1)
+echo "FILE_COUNT=$FILE_COUNT"
+```
+
+抽出失敗時は dry-run 出力をそのまま表示する。
+
+#### AskUserQuestion
+
+```yaml
+AskUserQuestion:
+  question: |
+    dry-run 結果:
+    - 同期モード: {SYNC_MODE}（initial = 初回 / existing = 既存メタあり）
+    - 対象ファイル数: {FILE_COUNT}
+    - 使用パッケージ: {CREATE_APP_PKG}
+
+    {dry-run 出力の主要部分}
+
+    本 sync を実行しますか?
+  header: "sync 実行可否"
+  options:
+    - label: "実行する（推奨）"
+      description: "上記差分でファイルを書き込む。Note: dry-run で安全性確認済みのため、続行が一般的。バックアップは create-app 側で自動取得される（既定 ON）"
+    - label: "dry-run のみで終了"
+      description: "今回は実行せず Skill 終了。Note: 差分内容を別途確認したい場合に有用"
+    - label: "取消"
+      description: "Skill を中断する。Note: 中断後は git status / stash 復元等は自動では行わない"
+    - label: "その他（自由入力）"
+      description: "上記以外の対応を伝える"
+```
+
+「実行する」 → Step 7。「dry-run のみ」「取消」 → 終了（Step 2 で stash した場合は復元案内）。
+
+---
+
+### Step 7: 本 sync 実行（2 系統）
+
+`SYNC_MODE` で分岐する。
+
+#### 7a: 初回経路（`SYNC_MODE=initial`）
+
+3-way merge の base スナップショットがなく、ローカル改変があれば conflict marker（`<<<<<<<` `=======` `>>>>>>>`）として残る可能性がある旨を予告する。
+
+```yaml
+AskUserQuestion:
+  question: |
+    初回 sync です（.einja-sync.json なし）。
+
+    3-way merge の base スナップショットが存在しないため、`packages/admin-ui` 配下にローカル改変があった場合、
+    変更が conflict marker としてファイル内に残る可能性があります。
+    backup は既定 ON のため、create-app 側のバックアップディレクトリに元ファイルが保存されます。
+
+    続行しますか?
+  header: "初回 sync 予告"
+  options:
+    - label: "続行する（推奨）"
+      description: "初回 sync を実行。Note: 初回 sync は backup ON で安全。conflict marker が残ったら Step 8 で報告する"
+    - label: "中断"
+      description: "Skill を終了する。Note: 既存改変を保護したい場合"
+    - label: "その他（自由入力）"
+      description: "上記以外の対応を伝える"
+```
+
+「続行する」を選んだら本実行へ:
+
+```bash
+SYNC_OUTPUT=$(npx -y "$CREATE_APP_PKG" sync \
+  --categories packages \
+  --packages-detail admin-ui \
+  --yes 2>&1)
+
+SYNC_EXIT=$?
+echo "$SYNC_OUTPUT"
+echo "EXIT=$SYNC_EXIT"
+```
+
+#### 7b: 既存メタあり経路（`SYNC_MODE=existing`）
+
+通常の 3-way merge で同一コマンドを実行する（予告 AskUserQuestion 不要、Step 6 で承認済み）:
+
+```bash
+SYNC_OUTPUT=$(npx -y "$CREATE_APP_PKG" sync \
+  --categories packages \
+  --packages-detail admin-ui \
+  --yes 2>&1)
+
+SYNC_EXIT=$?
+echo "$SYNC_OUTPUT"
+echo "EXIT=$SYNC_EXIT"
+```
+
+---
+
+### Step 8: 結果報告
+
+sync 出力から成功数 / コンフリクト数 / backup パスを抽出し、整形して報告する。
+
+```bash
+# 抽出例（出力フォーマットは create-app 側に依存）
+SUCCESS_N=$(echo "$SYNC_OUTPUT" | grep -oE "成功: [0-9]+" | grep -oE "[0-9]+" | head -1)
+CONFLICT_N=$(echo "$SYNC_OUTPUT" | grep -oE "コンフリクト: [0-9]+" | grep -oE "[0-9]+" | head -1)
+BACKUP_PATH=$(echo "$SYNC_OUTPUT" | grep -oE "backup: \S+" | head -1)
+
+# conflict marker が残っているファイルを検出
+CONFLICT_FILES=$(grep -l '<<<<<<<' -r packages/admin-ui 2>/dev/null || true)
+```
+
+#### 成功時の出力
+
+```markdown
+## admin-ui sync 完了
+
+### サマリ
+- **モード**: {SYNC_MODE}
+- **使用パッケージ**: {CREATE_APP_PKG}
+- **成功**: {SUCCESS_N} ファイル
+- **コンフリクト**: {CONFLICT_N} ファイル
+- **バックアップ**: {BACKUP_PATH}
+
+### 次のステップ
+- `git status` / `git diff packages/admin-ui` で結果確認
+- 問題なければコミット（einja-task-commit Skill 利用可）
+```
+
+#### コンフリクト検出時の AskUserQuestion
+
+`CONFLICT_FILES` が空でない場合:
+
+```yaml
+AskUserQuestion:
+  question: |
+    sync 完了後、以下のファイルに conflict marker が残っています。
+    マニュアルレビューが必要です。
+
+    {CONFLICT_FILES}
+  header: "conflict marker 残存"
+  options:
+    - label: "einja-conflict-resolver Skill を呼び出す（推奨）"
+      description: "コンフリクト解消 Skill にバトンタッチして 1 ファイルずつ解消する。Note: 対話的にコンフリクト解消するのが堅実。各ファイルで AskUserQuestion されるため対話的"
+    - label: "自分で手動修正する（Skill 終了）"
+      description: "コミット保留のまま Skill 終了。ユーザーが直接 editor で解消する。Note: einja-task-commit は conflict 残存中は呼ばないこと"
+    - label: "バックアップから復元してやり直す"
+      description: "{BACKUP_PATH} から元ファイルをコピーして sync を取り消し。Note: 今回の sync 結果はすべて破棄される"
+    - label: "その他（自由入力）"
+      description: "上記以外の対応を伝える"
+```
+
+#### 失敗時の出力
+
+```markdown
+## admin-ui sync 失敗
+
+### ステータス: FAILURE (exit={SYNC_EXIT})
+
+\`\`\`
+{SYNC_OUTPUT の末尾}
+\`\`\`
+
+### 推奨対応
+- `--packages-detail` 未対応バージョン → `EINJA_CREATE_APP_VERSION=latest` で再実行
+- ネットワーク失敗 → `npm view @einja-inc/create-app version` で疎通確認
+- detectProjectConfig 失敗 → package.json の name フィールド設定を確認
+```
+
+Step 2 で stash した場合は「`git stash pop` で復元してください」と案内する。
+
+---
+
+## トリガーキーワード一覧
+
+description の Use when... と一致させた呼び出しキーワード:
+
+- `admin-ui を sync`
+- `admin-ui sync`
+- `admin-ui 同期`
+- `shadcn コンポーネント同期`
+- `admin-ui upstream pull`
+- `admin-ui 更新取込`
+
+ネガティブトリガー（Do NOT use for）:
+
+- `docs/einja` の同期 → `npx @einja-inc/dev-cli sync`
+- テンプレ全体同期 → `npx @einja-inc/create-app sync`（対話）
+- `apps/*` の同期 → `npx @einja-inc/create-app sync --categories apps`
+
+---
+
+## トラブルシューティング
+
+| 症状 | 原因候補 | 対応 |
+|------|----------|------|
+| `--packages-detail` で「unknown option」 | npm cache 上の古いバージョンを引いた | `npx -y @einja-inc/create-app@latest --version` で確認後、`EINJA_CREATE_APP_VERSION=latest` 再実行 |
+| `detectProjectConfig` 失敗 | `package.json` の `name` フィールド未設定 / 壊れた JSON | package.json の name を有効値にして再実行 |
+| conflict marker が大量に出る | 初回 sync で `packages/admin-ui` のローカル改変が多い | 改変が意図的なら手動 merge、不要なら backup から復元して overwrite 戦略を将来検討（現状未実装） |
+| npx が古い tarball をキャッシュから引く | npm cache | `npm cache clean --force` 後に再実行（最終手段） |
+| `git status` が dirty のまま終了 | sync 自体が成功して新規ファイルが増えた状態 | `git add packages/admin-ui` で取り込み、einja-task-commit Skill でコミット |
+| `Invalid EINJA_CREATE_APP_VERSION` エラー | 環境変数が semver / `latest` 以外の値 | `latest` または `1.2.3` 形式に修正して再実行 |
+
+---
+
+## PENDING_QUESTIONS プロトコル
+
+不明点や判断が必要な場合は、推測で進めず `.claude/skills/_einja-subagent-question-protocol/SKILL.md` を参照して PENDING_QUESTIONS 形式で質問を返却し、作業を停止すること。
+
+該当ケース例:
+
+- dry-run 出力の差分件数が異常に多い（例: 100 ファイル超）
+- `EINJA_CREATE_APP_VERSION` 指定値が解決できない
+- Step 7 で予期せぬ exit code（128 等）
+- backup パスが取得できず復元手段が不明
+
+---
+
+## 参考資料
+
+- `packages/create-app/src/commands/sync.ts` — sync コマンドの実装（`--packages-detail`、`--yes`、`--dry-run`）
+- `.claude/skills/einja-conflict-resolver/SKILL.md` — コンフリクト解消の手順
+- `.claude/skills/einja-task-commit/SKILL.md` — sync 完了後のコミット
+- `.claude/skills/_einja-subagent-question-protocol/SKILL.md` — 不明時の質問プロトコル
+
+<!-- @einja:project-private:start id="einja-admin-ui-sync-project" -->
+<!-- プロジェクト固有の情報を記入 -->
+<!-- @einja:project-private:end -->

--- a/docs/plans/floofy-hatching-stream.md
+++ b/docs/plans/floofy-hatching-stream.md
@@ -1,0 +1,219 @@
+# admin-ui 同期の実用化（既存機構の検証 + Skill配布 + 最小CLI拡張）
+
+## Context
+
+`packages/admin-ui` はテンプレート（このリポジトリ）と子レポ（@einja-inc/create-app で生成）で共有されているが drift が発生している。調査の結果、同期機構は **既に存在** することが判明:
+
+- テンプレ側 `packages/create-app/scripts/template-update.ts` (prebuild) が `packages/admin-ui/` を `templates/default/packages/admin-ui/` にコピーし npm 配布
+- 子レポ側 `npx @einja-inc/create-app sync` に `packages` カテゴリ + `packagesDetail` で admin-ui 単独選択可、3-way merge / backup / rollback 完備
+- ファイル: `packages/create-app/src/commands/sync.ts`, `packages/create-app/src/generators/sync.ts`
+
+ユーザーの真の症状は「機構の不存在」ではなく **「機構の認知・利用不足」**。admin-ui の子レポ側改変は「ほぼ無い／不明」なので overwrite 寄りの sync で安全。
+
+**目標**: (1) 機構の end-to-end 動作を実機検証して信頼を確立、(2) `.claude/skills/einja-admin-ui-sync` を配布して認知・着手障壁を下げる、(3) Skill から完全非対話 sync を可能にする最小 CLI 拡張。
+
+---
+
+## 現状
+
+### 同期パイプライン（既存）
+
+```
+[テンプレ repo]                          [npm registry]                [子レポ]
+packages/admin-ui/                                                      packages/admin-ui/
+        ↓ template-update.ts (prebuild)                                      ↑ create-app sync
+packages/create-app/templates/default/   →  @einja-inc/create-app    →
+  packages/admin-ui/  (transform済み)        files: ["dist","templates"]
+```
+
+### sync.ts の制約（修正対象）
+
+`packages/create-app/src/commands/sync.ts:177-184` で `options.categories` 指定時に `packagesDetail` を強制 undefined にしているため、**Skill から非対話で admin-ui だけ sync する手段が無い**:
+
+```typescript
+if (options.categories) {
+  categories = options.categories as SyncCategory[];
+  appsDetail = undefined;
+  packagesDetail = undefined;  // ← これが問題
+  conflictStrategy = "merge";
+```
+
+### 不確実なポイント
+
+- `templates/default/packages/admin-ui/` が現在 HEAD では実体なし（prebuild 走行物・gitignore状況未確認）→ L1 検証で裏付け
+- `template-update.ts` の `transformContent` が admin-ui 内の `@repo/*` import を `{{packageName}}/*` に変換するが、子レポ展開時の placeholder 復元が `detectProjectConfig` 経由で正しく動くか未検証
+
+---
+
+## 変更内容
+
+### L1: 動作検証（コード変更なし）
+
+実機検証を3段階で実施し、現状の壊れ方を計測。
+
+| Step | コマンド/操作 | 期待結果 |
+|------|-------------|--------|
+| L1a | `pnpm --filter @einja-inc/create-app template:update --dry-run` を root から実行 | コピー予定ファイルに `packages/admin-ui/**` が含まれる |
+| L1b | 実走後 `diff -r packages/admin-ui/ packages/create-app/templates/default/packages/admin-ui/` | 差は `@repo/*` → `{{packageName}}/*` 変換と `package.json` / `tsconfig.json` placeholder のみ |
+| L1c | 一時 worktree or 既存子レポで `npx @einja-inc/create-app@latest sync --dry-run` を対話実行 → packages → admin-ui のみ選択 | dry-run リストに admin-ui ファイルが列挙される |
+
+### L2: Skill 配布（メイン成果物）
+
+新規 Skill: `.claude/skills/einja-admin-ui-sync/SKILL.md`
+
+**Skill 仕様**:
+- **name**: `einja-admin-ui-sync`
+- **配置先**: `.claude/skills/einja-admin-ui-sync/`（`einja-` プレフィックスで `copy-presets.mjs` の動的スキャンに自動載る）
+- **分類**: タスク型 / `user-invocable: true` / `context: fork` は付けない（AskUserQuestion と Bash 多用するため）
+- **description**: 「Syncs `packages/admin-ui` from the template repository to the current child project, with safety checks (git status, dry-run preview, conflict summary). Use when admin-ui drift is suspected or when picking up upstream component updates. Do NOT use for: docs/einja sync (→ `npx @einja-inc/dev-cli sync`), full template sync (→ `npx @einja-inc/create-app sync` 対話モード).」
+- **ワークフロー**:
+  1. **テンプレ repo 検出 → ブロック**: 以下のいずれかに該当する場合はテンプレ repo とみなし、AskUserQuestionで強制続行の脱出口を提示しつつデフォルト中断:
+     - `packages/create-app/` ディレクトリが存在
+     - `package.json.name === "einja-management-template"`
+     - （name はリネーム可能なので `packages/create-app/` の有無を主シグナルとする）
+  2. **git status クリーン確認**: dirty なら警告して中断オプション
+  3. **`.einja-sync.json` 存在チェック**（初回判定）
+     - 存在しない → 初回 sync 経路（後述）
+     - 存在する → 既存メタ経路（後述）
+  4. **dry-run 実行**:
+     - 既定: `npx @einja-inc/create-app@latest sync --categories packages --packages-detail admin-ui --dry-run --yes`
+     - 環境変数 `EINJA_CREATE_APP_VERSION` が設定されていればそれを使用（検証用に `@local` や `file:.../packages/create-app` を渡せるようにする）
+  5. **差分サマリ提示**: dry-run 出力を整形してユーザーに表示
+  6. **承認**: AskUserQuestion で「実行 / dry-run のみで終了 / 取消」
+  7. **本 sync**（2系統）:
+     - **初回経路（.einja-sync.json 不在）**: backup ON のまま `--categories packages --packages-detail admin-ui --yes`（3-way merge の base 不在で全 conflict 化する可能性があるが、conflict は merge marker としてファイルに残り backup から復元可能。AskUserQuestion で「初回なので全上書き許容」を選んだ場合は将来の `--overwrite` モードを使うことを案内 / 当面は merge marker 確認を推奨）
+     - **既存メタあり**: 通常 merge `--categories packages --packages-detail admin-ui --yes`
+  8. **結果報告**: 成功数 / コンフリクト数 / backup パスを表示。コンフリクトあれば手動レビュー指示
+
+### L3: 最小 CLI 拡張
+
+**変更ファイル**: `packages/create-app/src/commands/sync.ts`
+
+`sync.ts:177-184` の修正:
+
+```typescript
+if (options.categories) {
+  categories = options.categories as SyncCategory[];
+  appsDetail = options.appsDetail;        // 既存 CLI option がそのまま渡るように
+  packagesDetail = options.packagesDetail; // ← undefined 強制をやめる
+  conflictStrategy = "merge";
+```
+
+`SyncOptions` 型（`packages/create-app/src/types/index.ts`）に `appsDetail?: string[]` / `packagesDetail?: string[]` を追加。
+
+`bin` 定義（`packages/create-app/src/cli.ts` 等）で `--apps-detail <list>` / `--packages-detail <list>` オプションを追加。カンマ区切りパース。
+
+---
+
+## タスク概要
+
+### Phase 0: 事前準備
+
+- **タスク0-0**: TaskCreate で実装タスクを一括登録 [TaskCreate]
+- **タスク0-1**: Plan ファイルを `docs/plans/floofy-hatching-stream.md` に配置 [Bash]
+- **タスク0-2**: worktree `admin-ui-sync-enable` を作成・セットアップ [`_einja-worktree-guide`]
+- **タスク0-3**: Skill 雛形作成は L2 タスク内で実施するため不要（einja-skill-plan-guide ワークフローAは本Planで完結）
+
+### Phase 1: L1 動作検証（並列可能、結果次第で後続調整）
+
+- **タスク1-0**: `packages/create-app/scripts/template-update.ts` を Read し、`packages/admin-ui` がコピー対象に含まれる根拠（dirMappings の `{ src: "packages" }` エントリで `cli` と `create-app` のみ exclude → admin-ui は対象）を明示的に確認・ログ記録 [Read]
+- **タスク1-1**: L1a `pnpm --filter @einja-inc/create-app template:update --dry-run` 実行 → ログ確認 [Bash]
+- **タスク1-2**: L1b 実走 → 差分計測 → レポート出力 [Bash]
+- **タスク1-3**: L1c 子レポ／一時worktreeでの dry-run 実機検証 → 挙動ログ取得 [Bash]
+- **タスク1-4**: `create-app sync` の内部呼び出し元を grep し、`--categories` 経由以外の呼び出し（dev-cli からの内部呼び出し等）が無いことを確認（L3副作用範囲の事前計測）。コマンド: `grep -rn "syncCommand\|create-app.*sync\|categories" packages/create-app/src packages/cli/src --include="*.ts"` [Bash]
+
+→ タスク1-0で template-update.ts が想定どおりでなければ template-update.ts 修正タスクをPhase 2に先行追加。タスク1-4で意図せぬ内部呼び出しが見つかった場合はタスク2-2の実装方針を「optional propagation」に変更。深刻なブロッカーが見つかったら計画見直し。
+
+### Phase 2: L3 CLI 最小拡張（L2より先行）
+
+- **タスク2-1**: `SyncOptions` 型に `appsDetail` / `packagesDetail` 追加 [backend-implementer]
+- **タスク2-2**: `sync.ts:177-184` の `appsDetail = undefined` / `packagesDetail = undefined` を削除し options から引き継ぐ（タスク1-4の結果次第で `options.appsDetail ?? undefined` の optional propagation 形にする） [backend-implementer]
+- **タスク2-3**: `cli.ts`（または commander 定義箇所）に `--apps-detail` / `--packages-detail` フラグ追加。カンマ区切り → `string[]` パース [backend-implementer]
+- **タスク2-4**: 既存テスト `packages/create-app/src/commands/sync.test.ts` が壊れていないことを確認、新フラグの最小テスト追加 [backend-implementer]
+
+### Phase 3: L2 Skill 作成
+
+- **タスク3-1**: `.claude/skills/einja-admin-ui-sync/SKILL.md` を作成 [frontend-implementer or 直接編集]
+  - frontmatter (name, description, user-invocable: true)
+  - ワークフロー 7 ステップを記述
+  - 「子レポ検出」「git check」「dry-run」「承認」「本sync」「報告」のフロー
+  - references/ は本Skill不要（ロジック小）
+- **タスク3-2**: テンプレ repo で Skill を実機トリガー → 子レポ／worktree で挙動確認 [Bash]
+
+### Phase 4: 配布検証
+
+- **タスク4-1**: `pnpm --filter @einja-inc/dev-cli build` 実行後、`ls -la packages/cli/presets/default/.claude/skills/einja-admin-ui-sync/SKILL.md` でファイルの実在を明示的に確認（単に build 成功だけでなくファイル所在まで） [Bash]
+- **タスク4-2**: `.claude/rules/template-whitelist.md` 更新不要であることを確認（`einja-` プレフィックスは既に handled） [Read]
+
+### Phase 5: 完了検証（99系）
+
+- **タスク99-1**: 観点別並列コードレビュー [`einja-review-code`]
+- **タスク99-2**: 動作確認（Skill end-to-end 実行 + L3 オプションの CLI 単体テスト） [Bash]
+- **タスク99-G**: コミット承認ゲート [AskUserQuestion]
+- **タスク99-3**: コミット・プッシュ [`einja-task-commit`]
+
+---
+
+## 並列実行計画
+
+| グループ | タスク | 依存 |
+|---------|--------|------|
+| G0 (並列) | 1-0, 1-4 | なし（事前 Read / grep） |
+| G1 (並列) | 1-1, 1-2, 1-3 | G0 完了後（前提確認後） |
+| G2 (並列) | 2-1, 2-3 | G1 完了後（L1検証結果反映のため） |
+| G3 | 2-2 | 2-1, 1-4 |
+| G4 | 2-4 | 2-2, 2-3 |
+| G5 | 3-1 | G2-G4 完了後（L3 オプション前提のため） |
+| G6 | 3-2 | 3-1 + L3 のローカルビルド／linkが済んでいること |
+| G7 (並列) | 4-1, 4-2 | 3-1 完了後 |
+| G8 | 99系 | 全実装完了後、順次 |
+
+**最大並列数**: G0 で 2 並列、G1 で 3 並列、G2 で 2 並列、G7 で 2 並列。
+
+---
+
+## リスク・不明点
+
+| リスク | 影響 | 対策 |
+|--------|------|------|
+| L1で `templates/default/packages/admin-ui/` の生成自体が壊れている | L3/L2が無意味化 | L1検証で発覚 → 計画見直し、template-update.ts の修正を別タスクとして追加 |
+| 3-way merge の base 不在で初回 sync が全 conflict 化 | Skill UX劣化 | Skill 初回起動時に `.einja-sync.json` 存在チェック → 無ければ overwrite 戦略を AskUserQuestion で推奨 |
+| 子レポ側で `@einja-inc/create-app@latest` を `npx` で取る = 最新版だが、`SyncMetadata` schema 後方互換切れ | sync 失敗 | L1c で旧 schema の子レポでも動くか確認 |
+| `template-update.ts` の `transformContent` が admin-ui の `@repo/*` import 以外も変換してしまう副作用 | placeholder 残留 | L1b の diff で確認 |
+| テンプレ repo 自身で Skill を誤実行 | 自己上書き危険 | Skill 冒頭で `package.json.name === "einja-management-template"` を弾く |
+| `copy-presets.mjs` の prebuild が手動依存で、template-update も走らせないと npm publish 物が古い | drift の根源 | 別 Issue: npm-release Skill or CI で template:update --dry-run の差分0チェックを追加（本Plan外） |
+| L3 CLI 変更による既存 `sync.test.ts` のテスト失敗 | リグレッション | タスク2-4 でテスト確認・追加 |
+| **L3 のリリース順序制約**: L3 (`--packages-detail`) は npm publish するまで `@latest` には載らない。L2 Skill のワークフローは `@latest` を叩く設計なので、L3 publish 前に Skill を配布すると Skill が機能しない | Skill 機能不全 | (a) Skill のコマンドを `EINJA_CREATE_APP_VERSION` 環境変数で切替可能にし、検証中は `@local` や `file:.../packages/create-app` を使う、(b) MVP リリース順序を「L3 publish → L2 Skill 配布」と明示、(c) Skill 内に「対応版が公開されていない場合は対話モードへフォールバック」のガード追加を将来課題として記録 |
+| `create-app sync` 呼び出し元の意図せぬ伝播（タスク1-4で発覚し得る） | 既存利用者の挙動変化 | タスク2-2 を `options.packagesDetail ?? undefined` の optional propagation で実装し、CLI option 経由以外の呼び出しでは従来挙動を維持 |
+
+---
+
+## 検証・動作確認方法
+
+### L1 検証（実装着手前）
+
+1. `pnpm --filter @einja-inc/create-app template:update --dry-run` のログに `packages/admin-ui/` が現れることを確認
+2. 実走後 `diff -r packages/admin-ui/ packages/create-app/templates/default/packages/admin-ui/` で transform済み差分のみであることを確認
+3. 一時worktreeまたは既存子レポで `npx @einja-inc/create-app@latest sync --dry-run` 対話実行 → admin-ui ファイルが列挙されること
+
+### L3 CLI 単体テスト
+
+```bash
+# admin-ui のみ sync を非対話で要求
+npx @einja-inc/create-app@local sync --categories packages --packages-detail admin-ui --dry-run --yes
+# → admin-ui の差分のみ出力、他 packages は対象外
+```
+
+### L2 Skill end-to-end
+
+1. テンプレ repo を `pnpm --filter @einja-inc/dev-cli build` でビルド → `presets/default/.claude/skills/einja-admin-ui-sync/` が生成されることを `ls` で確認
+2. 一時 worktree で `npx @einja-inc/dev-cli@local init --force` を実行し Skill が配布されることを確認
+3. Skill トリガー: 「admin-ui を sync して」「admin-ui 同期」等で Skill が起動することを確認
+4. Skill ワークフロー完走: 子レポ検出 → git check → dry-run → 承認 → 本sync → 報告まで通る
+5. テンプレ repo 自身で Skill 起動 → 拒否されることを確認
+
+### 完了判定
+
+- 99-1: `einja-review-code` で MAJOR 0件
+- 99-2: L1〜L3すべての検証が pass
+- prepush（`einja-task-commit` 内）通過

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -165,6 +165,43 @@ npx @einja-inc/create-app add --all
 npx @einja-inc/create-app add --dry-run
 ```
 
+### `@einja-inc/create-app sync [options]`
+
+既存プロジェクトを最新テンプレートと同期します。3-way merge により、ローカル変更を保持しつつテンプレ更新を取り込みます。
+
+**オプション:**
+
+| オプション | 説明 | デフォルト |
+|----------|------|----------|
+| `--categories <categories>` | 同期対象カテゴリをカンマ区切りで指定 (e.g. `env,tools,packages`) | - |
+| `--apps-detail <apps>` | `apps` カテゴリ内で同期対象を絞り込む (e.g. `web,admin`) | - |
+| `--packages-detail <packages>` | `packages` カテゴリ内で同期対象を絞り込む (e.g. `admin-ui`) | - |
+| `--all` | 全カテゴリを同期（`apps`, `packages` 含む） | false |
+| `--dry-run` | 変更プレビューのみ（ファイル変更なし） | false |
+| `--backup` | 同期前にバックアップ作成 | true |
+| `--rollback` | 直近のバックアップから復元 | false |
+| `--force` | ローカル変更を無視して上書き | false |
+| `-y, --yes` | 安全な既定カテゴリで対話プロンプトなしに実行（`apps`, `packages` 除外）。`--categories` 併用時は指定カテゴリでも対話を抑制 | false |
+
+**使用例:**
+
+```bash
+# 対話モード（カテゴリを選択）
+npx @einja-inc/create-app sync
+
+# 安全な既定カテゴリのみ非対話で同期
+npx @einja-inc/create-app sync --yes
+
+# `packages/admin-ui` のみ非対話で同期（Skill `einja-admin-ui-sync` が内部で使用）
+npx @einja-inc/create-app sync --categories packages --packages-detail admin-ui --yes
+
+# 変更プレビューのみ
+npx @einja-inc/create-app sync --dry-run
+
+# 直近バックアップから復元
+npx @einja-inc/create-app sync --rollback
+```
+
 ---
 
 ## プロジェクト構成

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -13,6 +13,27 @@ const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
 
 const program = new Command();
 
+/**
+ * カンマ区切り文字列を配列に変換するヘルパー
+ * - 空文字・undefined は undefined を返す
+ * - 各要素は trim され、空文字は除外される
+ * - 全要素が空文字の場合は undefined を返す
+ *
+ * 例:
+ *   parseList(undefined) → undefined
+ *   parseList("") → undefined
+ *   parseList("  ,  ,  ") → undefined
+ *   parseList("env, tools") → ["env", "tools"]
+ */
+const parseList = (v?: string): string[] | undefined => {
+  if (!v) return undefined;
+  const parsed = v
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return parsed.length > 0 ? parsed : undefined;
+};
+
 program
   .name("create-app")
   .description("CLI tool to create new projects with Einja Management Template")
@@ -41,16 +62,29 @@ program
 program
   .command("sync")
   .description("Sync template files to existing project")
-  .option("--categories <categories>", "Comma-separated list of categories to sync")
+  .option(
+    "--categories <categories>",
+    "Comma-separated list of categories to sync (e.g. env,tools,packages)"
+  )
+  .option("--apps-detail <apps>", "Comma-separated list of apps to limit sync (e.g. web,admin)")
+  .option(
+    "--packages-detail <packages>",
+    "Comma-separated list of packages to limit sync (e.g. admin-ui)"
+  )
   .option("--all", "Sync all categories")
   .option("--dry-run", "Preview changes without making them")
   .option("--backup", "Create backup before syncing (default: true)", true)
   .option("--rollback", "Rollback to previous backup")
   .option("--force", "Force sync even with uncommitted changes")
-  .option("-y, --yes", "Sync safe categories without confirmation prompts (excludes apps, packages)")
+  .option(
+    "-y, --yes",
+    "Sync safe categories without confirmation prompts (excludes apps, packages). When combined with --categories, suppresses interactive prompts for any category."
+  )
   .action(
     async (options: {
       categories?: string;
+      appsDetail?: string;
+      packagesDetail?: string;
       all?: boolean;
       dryRun?: boolean;
       backup?: boolean;
@@ -58,15 +92,24 @@ program
       force?: boolean;
       yes?: boolean;
     }) => {
-      await syncCommand({
-        categories: options.categories?.split(","),
-        all: options.all || false,
-        dryRun: options.dryRun || false,
-        backup: options.backup !== false, // デフォルトtrue
-        rollback: options.rollback || false,
-        force: options.force || false,
-        yes: options.yes || false,
-      });
+      try {
+        await syncCommand({
+          categories: parseList(options.categories),
+          appsDetail: parseList(options.appsDetail),
+          packagesDetail: parseList(options.packagesDetail),
+          all: options.all || false,
+          dryRun: options.dryRun || false,
+          backup: options.backup !== false, // デフォルトtrue
+          rollback: options.rollback || false,
+          force: options.force || false,
+          yes: options.yes || false,
+        });
+      } catch (error) {
+        // syncCommand 内部で発生した例外（バリデーションエラー等）を
+        // 確実に fail-fast させるため、明示的に process.exit(1) する
+        console.error(error instanceof Error ? error.message : String(error));
+        process.exit(1);
+      }
     }
   );
 

--- a/packages/create-app/src/commands/sync.ts
+++ b/packages/create-app/src/commands/sync.ts
@@ -109,6 +109,12 @@ function getTemplatePath(): string {
 
 /**
  * sync コマンドのメイン関数
+ *
+ * 非対話モード: `--yes` または `--categories` 指定時は対話プロンプトを抑制し、
+ * 失敗時は `process.exit(1)` で fail-fast する。
+ *
+ * 詳細フィルタ: `--apps-detail` / `--packages-detail` で `apps` / `packages`
+ * カテゴリの subset を限定可能（commands/sync.ts L177-198 分岐）。
  */
 export async function syncCommand(options: SyncOptions): Promise<void> {
   const { existsSync } = fsExtra;
@@ -177,11 +183,29 @@ export async function syncCommand(options: SyncOptions): Promise<void> {
     if (options.categories) {
       // コマンドラインで指定されたカテゴリのみ（--yesや--allより優先）
       categories = options.categories as SyncCategory[];
-      appsDetail = undefined;
-      packagesDetail = undefined;
+      appsDetail = options.appsDetail;
+      packagesDetail = options.packagesDetail;
       conflictStrategy = "merge";
 
       logger.info(`指定されたカテゴリ: ${categories.join(", ")}`);
+      if (appsDetail && appsDetail.length > 0) {
+        if (categories.includes("apps")) {
+          logger.info(`apps詳細: ${appsDetail.join(", ")}`);
+        } else {
+          logger.warn(
+            "⚠ --apps-detail は --categories apps と併用してください（無視されます）"
+          );
+        }
+      }
+      if (packagesDetail && packagesDetail.length > 0) {
+        if (categories.includes("packages")) {
+          logger.info(`packages詳細: ${packagesDetail.join(", ")}`);
+        } else {
+          logger.warn(
+            "⚠ --packages-detail は --categories packages と併用してください（無視されます）"
+          );
+        }
+      }
     } else if (options.all) {
       // --all: 全カテゴリ選択（apps, packages含む）
       categories = getAllSyncCategories();
@@ -246,8 +270,11 @@ export async function syncCommand(options: SyncOptions): Promise<void> {
       // 検出失敗
       logger.warn("⚠️ プロジェクト設定を自動検出できませんでした");
 
-      if (options.yes) {
-        logger.error("❌ --yes モードではプロジェクト設定の自動検出が必須です");
+      // --yes でも --categories（非対話呼び出し）でも、対話プロンプトは出さずに失敗終了
+      if (options.yes || options.categories) {
+        logger.error(
+          "❌ 非対話モード（--yes / --categories）ではプロジェクト設定の自動検出が必須です"
+        );
         logger.error("プロジェクトのpackage.jsonにnameフィールドを設定してから再試行してください");
         process.exit(1);
       }

--- a/packages/create-app/src/generators/sync.ts
+++ b/packages/create-app/src/generators/sync.ts
@@ -3,6 +3,21 @@ import type { SyncCategory } from "@/types/index.js";
 import * as logger from "@/utils/logger.js";
 
 /**
+ * apps / packages の詳細名で許可する文字種パターン
+ *
+ * - 英数字 (a-z A-Z 0-9)
+ * - ハイフン (-)
+ * - アンダースコア (_)
+ * - ピリオド (.) ※ npm パッケージ名規約に従う
+ *
+ * 拒否される例:
+ *   - "../../etc/passwd"  (path traversal)
+ *   - "web/*"            (glob 特殊文字)
+ *   - "@scope/pkg"       (スコープ付き名: 詳細フィルタでは未対応)
+ */
+const SAFE_NAME_PATTERN = /^[a-zA-Z0-9._-]+$/;
+
+/**
  * カテゴリとファイルパターンのマッピング
  * prompts/sync.ts の CATEGORY_CONFIGS と同じ定義
  */
@@ -139,6 +154,29 @@ function extractPatternsFromCategories(
   appsDetail?: string[],
   packagesDetail?: string[]
 ): string[] {
+  // 安全のため、詳細パラメータは展開前に文字種をバリデートする
+  // （path traversal や glob 特殊文字を含む値を弾く）
+  if (appsDetail) {
+    for (const item of appsDetail) {
+      if (!SAFE_NAME_PATTERN.test(item)) {
+        logger.error(
+          `不正な app 名: ${item} (英数字・ハイフン・アンダースコア・ピリオドのみ許可)`
+        );
+        throw new Error(`Invalid apps-detail value: ${item}`);
+      }
+    }
+  }
+  if (packagesDetail) {
+    for (const item of packagesDetail) {
+      if (!SAFE_NAME_PATTERN.test(item)) {
+        logger.error(
+          `不正な package 名: ${item} (英数字・ハイフン・アンダースコア・ピリオドのみ許可)`
+        );
+        throw new Error(`Invalid packages-detail value: ${item}`);
+      }
+    }
+  }
+
   const patterns: string[] = [];
 
   for (const category of categories) {

--- a/packages/create-app/src/types/index.ts
+++ b/packages/create-app/src/types/index.ts
@@ -107,7 +107,9 @@ export type SyncCategoryConfig = {
  * 同期オプションの型定義
  */
 export type SyncOptions = {
-  categories?: string[]; // --categories env,tools
+  categories?: string[]; // --categories env,tools → ["env", "tools"]
+  appsDetail?: string[]; // --apps-detail web,admin → ["web", "admin"]
+  packagesDetail?: string[]; // --packages-detail admin-ui,ui → ["admin-ui", "ui"]
   all?: boolean; // --all
   dryRun?: boolean; // --dry-run
   backup?: boolean; // --backup (default: true)

--- a/packages/create-app/tests/unit/generators/sync.test.ts
+++ b/packages/create-app/tests/unit/generators/sync.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { collectSyncFiles } from "@/generators/sync.js";
+
+/**
+ * collectSyncFiles のフィルタリング動作テスト
+ *
+ * apps/packages カテゴリに対する詳細フィルタ（appsDetail / packagesDetail）が
+ * 正しく動作することを検証する。
+ *
+ * テンプレートディレクトリ全体を mock するのではなく、
+ * 一時ディレクトリに必要な最小限のファイル構造を作成して検証する。
+ */
+describe("collectSyncFiles - apps/packages 詳細フィルタ", { concurrent: false }, () => {
+  // テスト用一時テンプレートディレクトリ
+  const testTemplateDir = join(process.cwd(), "test-temp-sync-template");
+
+  /**
+   * テスト用テンプレートを作成
+   *
+   * 構造:
+   *   apps/web/page.tsx
+   *   apps/admin/page.tsx
+   *   packages/admin-ui/index.ts
+   *   packages/ui/button.tsx
+   */
+  function setupMockTemplate(): void {
+    mkdirSync(join(testTemplateDir, "apps/web"), { recursive: true });
+    mkdirSync(join(testTemplateDir, "apps/admin"), { recursive: true });
+    mkdirSync(join(testTemplateDir, "packages/admin-ui"), { recursive: true });
+    mkdirSync(join(testTemplateDir, "packages/ui"), { recursive: true });
+
+    writeFileSync(join(testTemplateDir, "apps/web/page.tsx"), "// web", "utf-8");
+    writeFileSync(join(testTemplateDir, "apps/admin/page.tsx"), "// admin", "utf-8");
+    writeFileSync(join(testTemplateDir, "packages/admin-ui/index.ts"), "// admin-ui", "utf-8");
+    writeFileSync(join(testTemplateDir, "packages/ui/button.tsx"), "// ui", "utf-8");
+  }
+
+  beforeEach(() => {
+    if (existsSync(testTemplateDir)) {
+      rmSync(testTemplateDir, { recursive: true, force: true });
+    }
+    setupMockTemplate();
+  });
+
+  afterEach(() => {
+    if (existsSync(testTemplateDir)) {
+      rmSync(testTemplateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("packagesDetail に admin-ui を指定すると packages/admin-ui/** のみが収集される", async () => {
+    // Given: categories=["packages"], packagesDetail=["admin-ui"]
+    // When: collectSyncFiles を実行
+    const files = await collectSyncFiles(
+      testTemplateDir,
+      ["packages"],
+      undefined,
+      ["admin-ui"]
+    );
+
+    // Then: packages/admin-ui のファイルのみが含まれる
+    expect(files).toContain("packages/admin-ui/index.ts");
+    // packages/ui は対象外
+    expect(files).not.toContain("packages/ui/button.tsx");
+    // 件数も検証（admin-ui には index.ts 1 ファイルのみ）
+    expect(files).toHaveLength(1);
+    expect(files.every((f) => f.startsWith("packages/admin-ui/"))).toBe(true);
+  });
+
+  it("appsDetail に web を指定すると apps/web/** のみが収集される", async () => {
+    // Given: categories=["apps"], appsDetail=["web"]
+    // When: collectSyncFiles を実行
+    const files = await collectSyncFiles(
+      testTemplateDir,
+      ["apps"],
+      ["web"],
+      undefined
+    );
+
+    // Then: apps/web のファイルのみが含まれる
+    expect(files).toContain("apps/web/page.tsx");
+    // apps/admin は対象外
+    expect(files).not.toContain("apps/admin/page.tsx");
+    // 件数も検証（web には page.tsx 1 ファイルのみ）
+    expect(files).toHaveLength(1);
+    expect(files.every((f) => f.startsWith("apps/web/"))).toBe(true);
+  });
+
+  it("packagesDetail に空配列を渡すと全 packages がマッチする", async () => {
+    // Given: categories=["packages"], packagesDetail=[]
+    // 空配列は「詳細指定なし」として扱われ、packages/** 全てが収集される
+    const files = await collectSyncFiles(testTemplateDir, ["packages"], undefined, []);
+
+    // Then: packages 配下の全ファイルが含まれる
+    expect(files).toContain("packages/admin-ui/index.ts");
+    expect(files).toContain("packages/ui/button.tsx");
+    expect(files).toHaveLength(2);
+  });
+
+  it("packagesDetail に複数指定すると指定された全 packages がマッチする", async () => {
+    // Given: categories=["packages"], packagesDetail=["admin-ui", "ui"]
+    const files = await collectSyncFiles(
+      testTemplateDir,
+      ["packages"],
+      undefined,
+      ["admin-ui", "ui"]
+    );
+
+    // Then: admin-ui と ui の両方のファイルが含まれる
+    expect(files).toContain("packages/admin-ui/index.ts");
+    expect(files).toContain("packages/ui/button.tsx");
+    expect(files).toHaveLength(2);
+  });
+
+  it("packagesDetail に存在しない名前を渡すと0件返る", async () => {
+    // Given: categories=["packages"], packagesDetail=["nonexistent"]
+    const files = await collectSyncFiles(
+      testTemplateDir,
+      ["packages"],
+      undefined,
+      ["nonexistent"]
+    );
+
+    // Then: マッチするファイルがないため空配列
+    expect(files).toEqual([]);
+    expect(files).toHaveLength(0);
+  });
+
+  it("appsDetail と packagesDetail を同時指定し、categories=['apps', 'packages'] でそれぞれフィルタされる", async () => {
+    // Given: categories=["apps", "packages"], appsDetail=["web"], packagesDetail=["admin-ui"]
+    const files = await collectSyncFiles(
+      testTemplateDir,
+      ["apps", "packages"],
+      ["web"],
+      ["admin-ui"]
+    );
+
+    // Then: apps/web と packages/admin-ui のみが収集される
+    expect(files).toContain("apps/web/page.tsx");
+    expect(files).toContain("packages/admin-ui/index.ts");
+    // apps/admin と packages/ui は対象外
+    expect(files).not.toContain("apps/admin/page.tsx");
+    expect(files).not.toContain("packages/ui/button.tsx");
+    expect(files).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

`packages/admin-ui` をテンプレートから子レポへ同期する既存機構を実用化。CLI 拡張、Skill 配布、セキュリティ強化、バグ修正を含む。

- **新機能**: `@einja-inc/create-app sync` に `--apps-detail <apps>` / `--packages-detail <packages>` CLI フラグを追加。`SyncOptions` 型を拡張
- **バグ修正**: `--yes` フラグが `--categories` 経路で対話プロンプトを抑制しなかった問題を修正（非対話モード時は `process.exit(1)` で fail-fast）
- **セキュリティ強化**: 詳細フラグ値に `parseList` helper（trim + filter Boolean）と `SAFE_NAME_PATTERN` バリデーション（英数字・ハイフン・アンダースコア・ピリオドのみ許可）を適用し、path traversal や glob 文字を拒否
- **Skill 追加**: `.claude/skills/einja-admin-ui-sync/` を新規作成。8 ステップワークフロー（テンプレ repo 検出 / git status / 初回判定 / dry-run / 差分サマリ / 承認 / 本 sync / 結果報告）。`EINJA_CREATE_APP_VERSION` の semver 検証でコマンドインジェクション対策
- **ドキュメント**: `packages/create-app/README.md` に `sync` コマンド章を新設（全フラグ + 使用例 4 パターン）
- **テスト**: `collectSyncFiles` の apps/packages 詳細フィルタ動作テストを 6 件追加（正常系 2 / 異常系 4）

## Changes

5 commits / 9 files:

| Commit | 内容 |
|--------|------|
| `a80e32b` | feat: create-app sync に --apps-detail / --packages-detail フラグと入力サニタイズを追加 |
| `9b501f4` | test: collectSyncFiles の apps/packages 詳細フィルタ動作テストを追加 |
| `8894bde` | docs: create-app README に sync コマンド章を追加 |
| `7359a52` | chore: changeset を追加 (admin-ui sync 詳細フラグ + --yes バグ修正) |
| `f777a23` | feat: admin-ui 同期 Skill (einja-admin-ui-sync) と Plan を追加 |

## Changeset

`.changeset/admin-ui-sync-detail-flag.md` (`@einja-inc/create-app` minor)

## Plan / 設計

- `docs/plans/floofy-hatching-stream.md`
- L1 動作検証 → L3 CLI 拡張 → L2 Skill 配布 → 99系完了検証 の順で実装
- Skill 設計は `einja-skill-plan-guide` ワークフローA に従って策定
- コードレビューは `einja-review-code` で 7 観点並列実行、MAJOR 4 件 + 主要 MINOR を反映

## Test plan

- [x] typecheck pass
- [x] `pnpm --filter @einja-inc/create-app test`: 120 passed / 2 skipped
- [x] prepush 全体: 630 passed / 1 skipped (7 workspace)
- [x] marker validation: 56 ファイル pass
- [x] dev-cli build → `presets/default/.claude/skills/einja-admin-ui-sync/SKILL.md` 自動配布確認
- [x] 実機検証 (mock child repo): `--packages-detail admin-ui` で 68 ファイル収集、サニタイズ 6 ケース（valid / 空 / 空白 / traversal / glob / mismatch）全て期待挙動

## 関連

- L3 (`--packages-detail` 対応) は npm publish 後に Skill が `@latest` 経由で機能開始する仕様。Skill 内では `EINJA_CREATE_APP_VERSION` 環境変数で `@local` 等への切替も可能
- H 観点（ログ強化 / observability / failure log / detectProjectConfig 失敗種別の構造化）は別 Issue 推奨