### PR TITLE
fix(issue-exec): ベースブランチ遅延対策 + teammate監視モード構造修正（信頼性向上）

### DIFF
--- a/.claude/hooks/einja/task-completed.sh
+++ b/.claude/hooks/einja/task-completed.sh
@@ -1,19 +1,35 @@
 #!/usr/bin/env bash
 # task-completed.sh — TaskCompleted hook
-# Agent Teams有効時のみ動作し、シグナルファイルを作成する
+# Agent Teams有効時、実効モードを判定せず常にシグナルファイルを作成する。
 #
-# 環境変数の出典:
+# 設計方針:
+#   teammate の実効モード（tmux pane / in-process）を hook から確実判定する公式手段は無いため、
+#   モード判定は行わず常にシグナルを生成する。in-process 時は Lead がシグナルを無視するので無害。
+#
+# 入力（公式: https://code.claude.com/docs/en/hooks ）:
+#   - stdin: JSON。team_name / task_id 等のフィールドを含む（主入力）
+# 環境変数:
 #   - CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: Agent Teams機能の有効化フラグ
-#   - CLAUDE_CODE_TEAMMATE_MODE: チームメイト実行モード（"tmux" | "in-process"）
-#   - CLAUDE_CODE_TASK_ID: Claude Code v2.1.33+ のhook実行コンテキストで提供される
-#     (公式: https://code.claude.com/docs/en/hooks )
-#   - EINJA_SESSION_ID: einja-team-exec Skillが起動時に設定するセッション識別子
-#
-# 実環境で変数名が異なる場合の調査用にデバッグログを残す（環境変数のみ。値は記録しない）
+#   - EINJA_SESSION_ID: einja-team-exec Skill が起動時に設定するセッション識別子（signal dir 決定の主経路）
+#   - CLAUDE_CODE_TASK_ID / CLAUDE_CODE_SESSION_ID / CLAUDE_SESSION_ID: stdin 未提供時の env フォールバック
 
 set -euo pipefail
 
-# デバッグログ: CLAUDE_CODE_* 環境変数の存在を記録（値は機密の可能性があるため変数名のみ）
+# stdin JSON を読み込む（公式 hooks は stdin で JSON を渡す）。空でも継続。
+HOOK_INPUT="$(cat 2>/dev/null || true)"
+
+# stdin JSON から指定キーの値を取り出す（node優先、jqフォールバック、取得不能なら空文字）
+json_get() {
+  local key="$1"
+  [ -z "$HOOK_INPUT" ] && return 0
+  if command -v node >/dev/null 2>&1; then
+    printf '%s' "$HOOK_INPUT" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const o=JSON.parse(d);const v=o[process.argv[1]];if(v!=null)process.stdout.write(String(v));}catch(e){}});' "$key" 2>/dev/null || true
+  elif command -v jq >/dev/null 2>&1; then
+    printf '%s' "$HOOK_INPUT" | jq -r --arg k "$key" '.[$k] // empty' 2>/dev/null || true
+  fi
+}
+
+# デバッグログ: CLAUDE_CODE_* / EINJA_* 環境変数の存在を記録（値は機密の可能性があるため変数名のみ）
 DEBUG_LOG="/tmp/einja-hooks-debug.log"
 {
   echo "[$(date '+%Y-%m-%dT%H:%M:%S%z')] task-completed.sh invoked"
@@ -25,26 +41,45 @@ if [ "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-}" != "1" ]; then
   exit 0
 fi
 
-# tmuxモード判定: in-process モードではシグナル生成を行わない
-# CLAUDE_CODE_TEAMMATE_MODE が未設定の場合は tmux モードを仮定（後方互換）
-TEAMMATE_MODE="${CLAUDE_CODE_TEAMMATE_MODE:-tmux}"
-if [ "$TEAMMATE_MODE" != "tmux" ]; then
-  exit 0
-fi
-
-# セッションID解決: EINJA_SESSION_ID → CLAUDE_CODE_SESSION_ID → CLAUDE_SESSION_ID の順で探索
-SESSION_ID="${EINJA_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}}"
+# セッションID解決（signal dir 決定）:
+#   1. EINJA_SESSION_ID（主経路。Lead/Teammate で共有する issue-{N} 等）
+#   2. stdin JSON の team_name から命名サフィックス（-directors/-workers）を除去して復元
+#   3. CLAUDE_CODE_SESSION_ID → CLAUDE_SESSION_ID（プラットフォーム提供時）
+# team_name をそのまま使わないのは、Lead が監視する signal dir（issue-{N}）とズレるため。
+SESSION_ID="${EINJA_SESSION_ID:-}"
 if [ -z "$SESSION_ID" ]; then
-  echo "[task-completed.sh] WARN: セッションIDが解決できませんでした (EINJA_SESSION_ID/CLAUDE_CODE_SESSION_ID/CLAUDE_SESSION_ID すべて未設定)。シグナルファイルは生成しません。" >&2
+  TEAM_NAME="$(json_get team_name)"
+  if [ -n "$TEAM_NAME" ]; then
+    SESSION_ID="$(printf '%s' "$TEAM_NAME" | sed -E 's/-(directors|workers)$//')"
+  fi
+fi
+if [ -z "$SESSION_ID" ]; then
+  SESSION_ID="${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
+fi
+if [ -z "$SESSION_ID" ]; then
+  echo "[task-completed.sh] WARN: セッションIDが解決できませんでした (EINJA_SESSION_ID / stdin team_name / CLAUDE_CODE_SESSION_ID / CLAUDE_SESSION_ID すべて未取得)。シグナルファイルは生成しません。" >&2
   echo "[$(date '+%Y-%m-%dT%H:%M:%S%z')] task-completed.sh: session id unresolved" >>"$DEBUG_LOG" 2>/dev/null || true
   exit 0
 fi
 
+# SESSION_ID サニタイズ（path-traversal 防止）: signal dir のパス成分になるため、
+# 安全な文字以外を `_` に置換し、`..`/空/ドット単体は拒否する（task_id/teammate_name と同等の防御を SESSION_ID にも一貫適用）。
+SESSION_ID="$(printf '%s' "$SESSION_ID" | tr -c 'A-Za-z0-9._-' '_')"
+case "$SESSION_ID" in
+  '' | . | .. | *..*)
+    echo "[task-completed.sh] WARN: 不正な SESSION_ID（path-traversal の恐れ）を検出しました。シグナルファイルは生成しません。" >&2
+    exit 0
+    ;;
+esac
+
 SIGNAL_DIR="$HOME/.einja/sessions/${SESSION_ID}/signals"
 mkdir -p "$SIGNAL_DIR"
 
-TASK_ID="${CLAUDE_CODE_TASK_ID:-unknown}"
-# ファイル名サニタイズ: `/` や空白等が含まれるとパス分割やファイル名不具合を引き起こすため、
-# 安全な文字（英数字、ドット、アンダースコア、ハイフン）以外を `_` に置換する
+# Task ID: stdin JSON 優先、env フォールバック
+TASK_ID="$(json_get task_id)"
+if [ -z "$TASK_ID" ]; then
+  TASK_ID="${CLAUDE_CODE_TASK_ID:-unknown}"
+fi
+# ファイル名サニタイズ: 安全な文字（英数字、ドット、アンダースコア、ハイフン）以外を `_` に置換
 safe_task_id=$(printf '%s' "$TASK_ID" | tr -c 'A-Za-z0-9._-' '_')
 touch "$SIGNAL_DIR/task-${safe_task_id}-completed.signal"

--- a/.claude/hooks/einja/teammate-idle.sh
+++ b/.claude/hooks/einja/teammate-idle.sh
@@ -1,19 +1,35 @@
 #!/usr/bin/env bash
 # teammate-idle.sh — TeammateIdle hook
-# Agent Teams有効時のみ動作し、シグナルファイルを作成する
+# Agent Teams有効時、実効モードを判定せず常にシグナルファイルを作成する。
 #
-# 環境変数の出典:
+# 設計方針:
+#   teammate の実効モード（tmux pane / in-process）を hook から確実判定する公式手段は無いため、
+#   モード判定は行わず常にシグナルを生成する。in-process 時は Lead がシグナルを無視するので無害。
+#
+# 入力（公式: https://code.claude.com/docs/en/hooks ）:
+#   - stdin: JSON。team_name / teammate_name 等のフィールドを含む（主入力）
+# 環境変数:
 #   - CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS: Agent Teams機能の有効化フラグ
-#   - CLAUDE_CODE_TEAMMATE_MODE: チームメイト実行モード（"tmux" | "in-process"）
-#   - CLAUDE_CODE_TEAMMATE_NAME: Claude Code v2.1.33+ のhook実行コンテキストで提供される
-#     (公式: https://code.claude.com/docs/en/hooks )
-#   - EINJA_SESSION_ID: einja-team-exec Skillが起動時に設定するセッション識別子
-#
-# 実環境で変数名が異なる場合の調査用にデバッグログを残す（環境変数のみ。値は記録しない）
+#   - EINJA_SESSION_ID: einja-team-exec Skill が起動時に設定するセッション識別子（signal dir 決定の主経路）
+#   - CLAUDE_CODE_TEAMMATE_NAME / CLAUDE_CODE_SESSION_ID / CLAUDE_SESSION_ID: stdin 未提供時の env フォールバック
 
 set -euo pipefail
 
-# デバッグログ: CLAUDE_CODE_* 環境変数の存在を記録（値は機密の可能性があるため変数名のみ）
+# stdin JSON を読み込む（公式 hooks は stdin で JSON を渡す）。空でも継続。
+HOOK_INPUT="$(cat 2>/dev/null || true)"
+
+# stdin JSON から指定キーの値を取り出す（node優先、jqフォールバック、取得不能なら空文字）
+json_get() {
+  local key="$1"
+  [ -z "$HOOK_INPUT" ] && return 0
+  if command -v node >/dev/null 2>&1; then
+    printf '%s' "$HOOK_INPUT" | node -e 'let d="";process.stdin.on("data",c=>d+=c);process.stdin.on("end",()=>{try{const o=JSON.parse(d);const v=o[process.argv[1]];if(v!=null)process.stdout.write(String(v));}catch(e){}});' "$key" 2>/dev/null || true
+  elif command -v jq >/dev/null 2>&1; then
+    printf '%s' "$HOOK_INPUT" | jq -r --arg k "$key" '.[$k] // empty' 2>/dev/null || true
+  fi
+}
+
+# デバッグログ: CLAUDE_CODE_* / EINJA_* 環境変数の存在を記録（値は機密の可能性があるため変数名のみ）
 DEBUG_LOG="/tmp/einja-hooks-debug.log"
 {
   echo "[$(date '+%Y-%m-%dT%H:%M:%S%z')] teammate-idle.sh invoked"
@@ -25,26 +41,45 @@ if [ "${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-}" != "1" ]; then
   exit 0
 fi
 
-# tmuxモード判定: in-process モードではシグナル生成を行わない
-# CLAUDE_CODE_TEAMMATE_MODE が未設定の場合は tmux モードを仮定（後方互換）
-TEAMMATE_MODE="${CLAUDE_CODE_TEAMMATE_MODE:-tmux}"
-if [ "$TEAMMATE_MODE" != "tmux" ]; then
-  exit 0
-fi
-
-# セッションID解決: EINJA_SESSION_ID → CLAUDE_CODE_SESSION_ID → CLAUDE_SESSION_ID の順で探索
-SESSION_ID="${EINJA_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}}"
+# セッションID解決（signal dir 決定）:
+#   1. EINJA_SESSION_ID（主経路。Lead/Teammate で共有する issue-{N} 等）
+#   2. stdin JSON の team_name から命名サフィックス（-directors/-workers）を除去して復元
+#   3. CLAUDE_CODE_SESSION_ID → CLAUDE_SESSION_ID（プラットフォーム提供時）
+# team_name をそのまま使わないのは、Lead が監視する signal dir（issue-{N}）とズレるため。
+SESSION_ID="${EINJA_SESSION_ID:-}"
 if [ -z "$SESSION_ID" ]; then
-  echo "[teammate-idle.sh] WARN: セッションIDが解決できませんでした (EINJA_SESSION_ID/CLAUDE_CODE_SESSION_ID/CLAUDE_SESSION_ID すべて未設定)。シグナルファイルは生成しません。" >&2
+  TEAM_NAME="$(json_get team_name)"
+  if [ -n "$TEAM_NAME" ]; then
+    SESSION_ID="$(printf '%s' "$TEAM_NAME" | sed -E 's/-(directors|workers)$//')"
+  fi
+fi
+if [ -z "$SESSION_ID" ]; then
+  SESSION_ID="${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
+fi
+if [ -z "$SESSION_ID" ]; then
+  echo "[teammate-idle.sh] WARN: セッションIDが解決できませんでした (EINJA_SESSION_ID / stdin team_name / CLAUDE_CODE_SESSION_ID / CLAUDE_SESSION_ID すべて未取得)。シグナルファイルは生成しません。" >&2
   echo "[$(date '+%Y-%m-%dT%H:%M:%S%z')] teammate-idle.sh: session id unresolved" >>"$DEBUG_LOG" 2>/dev/null || true
   exit 0
 fi
 
+# SESSION_ID サニタイズ（path-traversal 防止）: signal dir のパス成分になるため、
+# 安全な文字以外を `_` に置換し、`..`/空/ドット単体は拒否する（task_id/teammate_name と同等の防御を SESSION_ID にも一貫適用）。
+SESSION_ID="$(printf '%s' "$SESSION_ID" | tr -c 'A-Za-z0-9._-' '_')"
+case "$SESSION_ID" in
+  '' | . | .. | *..*)
+    echo "[teammate-idle.sh] WARN: 不正な SESSION_ID（path-traversal の恐れ）を検出しました。シグナルファイルは生成しません。" >&2
+    exit 0
+    ;;
+esac
+
 SIGNAL_DIR="$HOME/.einja/sessions/${SESSION_ID}/signals"
 mkdir -p "$SIGNAL_DIR"
 
-TEAMMATE_NAME="${CLAUDE_CODE_TEAMMATE_NAME:-unknown}"
-# ファイル名サニタイズ: `/` や空白等が含まれるとパス分割やファイル名不具合を引き起こすため、
-# 安全な文字（英数字、ドット、アンダースコア、ハイフン）以外を `_` に置換する
+# Teammate 名: stdin JSON 優先、env フォールバック
+TEAMMATE_NAME="$(json_get teammate_name)"
+if [ -z "$TEAMMATE_NAME" ]; then
+  TEAMMATE_NAME="${CLAUDE_CODE_TEAMMATE_NAME:-unknown}"
+fi
+# ファイル名サニタイズ: 安全な文字（英数字、ドット、アンダースコア、ハイフン）以外を `_` に置換
 safe_teammate_name=$(printf '%s' "$TEAMMATE_NAME" | tr -c 'A-Za-z0-9._-' '_')
 touch "$SIGNAL_DIR/teammate-idle-${safe_teammate_name}.signal"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,6 @@
 {
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "CLAUDE_CODE_TEAMMATE_MODE": "tmux",
     "CLAUDE_MEM_DATA_DIR": ".claude-mem",
     "CLAUDE_CODE_NO_FLICKER": "1"
   },

--- a/.claude/skills/einja-issue-exec/SKILL.md
+++ b/.claude/skills/einja-issue-exec/SKILL.md
@@ -461,7 +461,7 @@ Manager は以下を監視:
       b. **自力回答不可の場合**: `AskUserQuestion` でユーザーに質問を転送（Worker ID・質問内容を含める）。ユーザーの回答を受け取り次第、`tmux send-keys -t "$WORKER_PANE" "{ユーザーの回答}" Enter` で Worker pane に送信
    4. Worker は回答を受け取り自動的に作業を再開する
 
-2. **Worker完了後のゲートチェック**: 詳細は issue-exec-protocol.md「ゲートチェック仕様」を参照。ゲート通過後はマージモードに応じた**タスクPRマージ処理**（タスクPRはWorker側のeinja-task-exec Step 7.5で作成済み。ManagerはタスクPRを自ら作成しない） → **Issue説明文のチェックボックス更新**（protocol.md「2.3 completed 遷移時の必須アクション」参照）→ 他active Workerにsync通知。**Worker pane・worktreeはPhase完了まで維持する**（修正指示に備えるため）
+2. **Worker完了後のゲートチェック**: 詳細は issue-exec-protocol.md「ゲートチェック仕様」を参照。ゲート通過後はマージモードに応じた**タスクPRマージ処理**（タスクPRはWorker側のeinja-task-exec Step 7.5で作成済み。ManagerはタスクPRを自ら作成しない） → **Issue説明文のチェックボックス更新**（protocol.md「2.3 completed 遷移時の必須アクション」参照）→ 他 active Worker は次タスク開始時に最新 Phase ブランチを取り込む（`task/{N}-{X.Y}` は単独所有のため rebase 可。base 取込は Manager が §12.3.1 で実施）。**Worker pane・worktreeはPhase完了まで維持する**（修正指示に備えるため）
 
 3. **質問エスカレーション処理（tmux Worker質問転送フロー — モード1）**:
 
@@ -603,7 +603,7 @@ Agent tool は完了時に結果を返すため、ポーリング不要:
    - 残りのPhase（ある場合）
 3. **AskUserQuestion で次のアクションを確認**:
    - **次のPhaseを実行**: 次のPhaseの実行を開始
-     - Note: 現在のPhaseがマージ済みであることを確認してから開始
+     - Note: 現在のPhaseがマージ済みであることを確認。**着手前に Phase境界強制同期（§12.3.1）を実行** — `git fetch origin` → `git rev-list --count "issue/{N}..origin/{baseBranch}"` で behind 判定 → behind>0 なら `git merge --no-edit origin/{baseBranch}`（衝突→einja-conflict-resolver）→ `git push origin issue/{N}`（lock系→§12.2）。push成功後に次Phaseブランチを最新 issue/{N} から作成。詳細: issue-exec-protocol.md §12.3.1
    - **修正を実施**: レビュー指摘やテスト結果に基づく修正を実行
      - Note: 修正対象のPR番号・指摘内容を入力。該当Workerを再起動して修正
    - **セッションを終了**: worktree・セッションファイルをクリーンアップして終了
@@ -613,6 +613,19 @@ Agent tool は完了時に結果を返すため、ポーリング不要:
 ### Step 8: 全Phase完了 → 最終PR・待機
 
 全Phaseが完了した場合:
+
+> **最終PR前ゲート（§12.3.2・必須）**: 下記「1. 最終PR作成」の実行直前に `issue/{N}` を base から最新化し、CONFLICTING/DIRTY な最終PRを構造的に防ぐ:
+> ```bash
+> git fetch origin
+> BEHIND=$(git rev-list --count "issue/{N}..origin/{baseBranch}")
+> if [ "$BEHIND" -gt 0 ]; then
+>   git merge --no-edit "origin/{baseBranch}"   # 衝突→einja-conflict-resolver / push失敗→§12.2
+>   git push origin "issue/{N}"
+> fi
+> # push 成功を確認してから「1. 最終PR作成」を実行すること
+> ```
+> 詳細: issue-exec-protocol.md §12.3.2
+
 1. 最終PR作成: `/einja-create-pr --auto --base {baseBranch}` を実行
 2. PR URL を表示
 3. **セッションを維持したまま待機モード**に入る（クリーンアップしない）
@@ -754,6 +767,7 @@ result の値:
 | Worker異常終了（修正中・Agent tool） | Agent tool エラー応答 + directorVerdict=fix_required | Managerが再起動（fixCount引き継ぎ）→ 上限超過時はユーザーにエスカレーション |
 | Manager異常終了 | ユーザー手動 | `--resume` でセッション復元 |
 | rebaseコンフリクト | git rebase失敗 | einja-conflict-resolver Skillで自力解消 |
+| mergeコンフリクト（base取込: Phase境界/最終PRゲート） | git merge失敗 | einja-conflict-resolver Skillで解消 → 解消不可ならユーザーにエスカレーション |
 | CI失敗 | gh run status | 修正 → 再push → 再CI待機 |
 
 ## 質問回答のドキュメント還元
@@ -851,4 +865,4 @@ tmux send-keys -t "$WORKER_PANE" '/einja-task-exec #{N} {X.Y}' Enter
 - Worker 内部のタスク並列実行は既存の einja-task-exec Skill フロー（Task ツール + run_in_background）をそのまま活用
 - ステータスファイルの `status.json` 更新には `flock` による排他制御を使用
 - 質問ファイルは1ファイル1質問のためロック不要（UUID でアトミック書き込み）
-- Worker は各タスク完了毎 + PR作成前にステータスファイルをチェック（sync_required検知時は次タスク開始前にrebase）
+- Worker は各タスク完了毎 + PR作成前にステータスファイルをチェックし、Manager が Phase ブランチを最新化していれば次タスク開始前に取り込む（`task/{N}-{X.Y}` は単独所有のため rebase 可）

--- a/.claude/skills/einja-issue-team-exec/SKILL.md
+++ b/.claude/skills/einja-issue-team-exec/SKILL.md
@@ -75,11 +75,11 @@ GitHub Issue 全体のタスクを Lead → Director(Teammate Pool) → Worker(S
 
 > **【必須】処理開始前に `einja-common:agent-teams-guide` Skill を Skill ツールで読み込むこと。** TeamCreate / teammate 管理 / ファイル競合防止策 / フォールバック手順といった Agent Teams 利用時の必守ルールを参照するため、本 Skill 起動直後に最初に実行する。
 >
-> **汎用の Agent Teams 有効確認・表示モード検出は [`einja-team-exec/SKILL.md` Step 1-A](../einja-team-exec/SKILL.md#step-1-a-前提条件環境検出) を参照。**
+> **汎用の Agent Teams 有効確認・Lead 監視モード resolve（tmux/in-process の判定。`CLAUDE_CODE_TEAMMATE_MODE` には依存しない）は [`einja-team-exec/SKILL.md` Step 1-A](../einja-team-exec/SKILL.md#step-1-a-環境検出) を参照。**
 >
 > ### 【最重要・上書き】汎用 fallback の不継承
 >
-> [`einja-team-exec/SKILL.md` Step 1-A（およびフォールバック節 Step 1-A-fb）](../einja-team-exec/SKILL.md#step-1-a-前提条件環境検出) では「Agent Teams 無効時は Agent tool (Task) ベースの並列実行へ自動 fallback する」と定義されているが、**本 Skill（einja-issue-team-exec）ではこの汎用 fallback を継承しない**。
+> [`einja-team-exec/SKILL.md` Step 1-A（およびフォールバック節 Step 1-A-fb）](../einja-team-exec/SKILL.md#step-1-a-環境検出) では「Agent Teams 無効時は Agent tool (Task) ベースの並列実行へ自動 fallback する」と定義されているが、**本 Skill（einja-issue-team-exec）ではこの汎用 fallback を継承しない**。
 >
 > 理由: Issue 並列実行は Issue 単位の Phase / タスクグループ / PR Gate / verdict フロー / docs-updater / Phase 99 等の前提に依存しており、Agent tool ベースの汎用 fallback では Issue 固有の Lead↔Director↔Worker メッセージング・PR ゲートチェック・Phase ブランチ運用が成立しないため。
 >

--- a/.claude/skills/einja-issue-team-exec/SKILL.md
+++ b/.claude/skills/einja-issue-team-exec/SKILL.md
@@ -539,6 +539,14 @@ Phase PR 作成後、**Lead が `Skill` ツールで `_einja-phase-review` を�
 
 ```bash
 git fetch origin
+# §12.3.1 Phase境界強制同期: 次Phaseブランチ作成前に issue/${N} を base(${baseBranch}) から最新化（merge-only・冪等）
+# ※ issue/${N} をチェックアウトしているツリーで実行すること
+BEHIND=$(git rev-list --count "issue/${N}..origin/${baseBranch}")
+if [ "$BEHIND" -gt 0 ]; then
+  git merge --no-edit "origin/${baseBranch}"   # 衝突→einja-conflict-resolver / push失敗→§12.2リトライ
+  git push origin "issue/${N}"
+fi
+# push 成功を確認してから次Phaseブランチを最新 origin/issue/${N} から作成/追従
 BRANCH="issue/${N}-phase{M+1}"
 BASE="origin/issue/${N}"
 if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
@@ -563,7 +571,7 @@ git push -u origin "$BRANCH" 2>/dev/null || true
 1. Phase PR 作成（未作成時）: `einja-create-pr` Skill で作成
 2. 完了報告をユーザーに表示（完了 Phase、作成 PR 一覧、残り Phase）
 3. **AskUserQuestion で次のアクションを確認**:
-   - **次の Phase を実行**: idle Director が新タスクを claim。現 Phase がマージ済みであることを確認してから開始
+   - **次の Phase を実行**: idle Director が新タスクを claim。現 Phase がマージ済みであることを確認してから開始（base 取込の Phase境界強制同期 §12.3.1 は「マージ後の次 Phase 準備」セクションで実行済みであることを前提とする）
    - **修正を実施**: レビュー指摘やテスト結果に基づく修正。修正対象 PR 番号・指摘内容を入力 → 該当 Director に SendMessage
    - **セッションを終了**: チーム解散・クリーンアップ
    - **その他（自由入力）**: 追加指示
@@ -571,6 +579,17 @@ git push -u origin "$BRANCH" 2>/dev/null || true
 ## Step 8: 全 Phase 完了 → 最終 PR・待機
 
 全 Phase 完了時:
+
+> **最終PR前ゲート（§12.3.2・必須）**: 下記「1. 最終 PR 作成」の直前に issue/${N} を base から最新化し、CONFLICTING/DIRTY な最終PRを構造的に防ぐ:
+> ```bash
+> git fetch origin
+> BEHIND=$(git rev-list --count "issue/${N}..origin/${baseBranch}")
+> if [ "$BEHIND" -gt 0 ]; then
+>   git merge --no-edit "origin/${baseBranch}"   # 衝突→einja-conflict-resolver / push失敗→§12.2
+>   git push origin "issue/${N}"
+> fi
+> ```
+> 詳細: issue-exec-protocol.md §12.3.2
 
 1. `einja-create-pr` Skill で最終 PR 作成:
    ```

--- a/.claude/skills/einja-issue-team-exec/director-prompt.md
+++ b/.claude/skills/einja-issue-team-exec/director-prompt.md
@@ -52,6 +52,8 @@ Director は claim 後、タスクグループの description から個別タス
 > **明示的な上書き**: 汎用テンプレートでは `{WORKTREE_PATH}` プレースホルダーで任意のパスを許容しているが、Issue 並列実行（派生 Skill）では Issue 番号 `{N}` とタスクグループ番号 `{X.Y}` / 個別タスク番号 `{X.Y.Z}` を含む上記命名で固定する。これは PR / ブランチ運用との整合性、resume 時の検索容易性、`task/{N}-` プレフィックスによる一括クリーンアップ（SKILL.md Step 9 参照）を成立させるため。
 >
 > 冪等な作成・削除手順は汎用テンプレートの Step 2 / Step 3 を参照（命名のみ上記で置換）。
+>
+> **注**: 上記 base（`origin/issue/{N}-phase{M}`）は、Lead/Manager が Phase 境界で issue/{N} を IssueBranchBase から最新化済み（§12.3.1）であることを前提とする。Director は worktree 作成直前に `git fetch origin` を実行し、最新の base を参照すること。
 
 ## Issue 固有のメインフロー差分
 

--- a/.claude/skills/einja-team-exec/SKILL.md
+++ b/.claude/skills/einja-team-exec/SKILL.md
@@ -69,17 +69,41 @@ echo $CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS
 | `1` | Agent Teams モードで続行 |
 | 空 / 未設定 | **フォールバック**: Agent tool + foreground subagent 方式に自動切替（Step 1-A-fb 参照） |
 
-### 表示モード検出
+### Lead 監視モード resolve
+
+teammate の実効モード（tmux pane / in-process）を hook/SKILL から確実判定する公式手段は無い（`CLAUDE_CODE_TEAMMATE_MODE` は Claude Code が公式提供しない env var）。そのため **Lead 自身が監視モードを決める**。hooks はモード判定せず Agent Teams 有効時は常時シグナルを生成するため、Lead が in-process と判定した場合はシグナルを無視すればよい。
+
+解決順（先に決まったものを採用）:
+1. `EINJA_TEAMMATE_MONITOR_MODE`（einja 明示指定: `tmux` / `in-process`）
+2. settings.json の top-level `teammateMode`（project → user。`tmux` / `in-process` / `auto`）
+3. 既定 `auto`
 
 ```bash
-echo $CLAUDE_CODE_TEAMMATE_MODE
-echo $TMUX
+MODE="${EINJA_TEAMMATE_MONITOR_MODE:-}"
+# 未指定なら settings.json の top-level teammateMode を読む（project: ./.claude/settings.json → user: ~/.claude/settings.json）
+# 読み取りは node（fs.readFileSync + JSON.parse。require 回避）優先、jq フォールバック。JSONCコメント非対応前提。
+if [ -z "$MODE" ]; then
+  for f in "$PWD/.claude/settings.json" "$HOME/.claude/settings.json"; do
+    [ -f "$f" ] || continue
+    v="$(node -e 'try{const j=JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"));if(j.teammateMode!=null)process.stdout.write(String(j.teammateMode))}catch(e){}' "$f" 2>/dev/null \
+      || jq -r '.teammateMode // empty' "$f" 2>/dev/null || true)"
+    [ -n "$v" ] && { MODE="$v"; break; }
+  done
+fi
+[ -z "$MODE" ] && MODE="auto"   # いずれも未取得なら既定 auto
+# auto / tmux は実環境を確認して降格判定する:
+#   $TMUX 非空 かつ `tmux list-panes` 成功 → tmux、それ以外/失敗 → in-process へ降格
+if { [ "$MODE" = "tmux" ] || [ "$MODE" = "auto" ]; } && [ -n "${TMUX:-}" ] && tmux list-panes >/dev/null 2>&1; then
+  MONITOR_MODE="tmux"
+else
+  MONITOR_MODE="in-process"
+fi
 ```
 
-| 環境 | 監視方式 |
+| MONITOR_MODE | 監視方式 |
 |------|---------|
-| `CLAUDE_CODE_TEAMMATE_MODE=tmux` かつ `$TMUX` が非空 | tmuxモード: シグナルファイル + tmux pane監視 |
-| 上記以外 | in-processモード: SendMessage受信 + TaskList確認 |
+| `tmux` | シグナルファイル + tmux pane監視。**併せて SendMessage / TaskList poll も実施**（#29207 の silent in-process fallback 保険として取りこぼしを防ぐ） |
+| `in-process` | SendMessage受信 + TaskList確認。hooks のシグナルは取りこぼし検知の補助としてのみ使用 |
 
 ### フォールバック（Agent Teams 無効時）— Step 1-A-fb
 
@@ -367,7 +391,7 @@ Director は以下の場合に Lead へエスカレーションする:
 |-------|---------|------|
 | Agent Teams in-process | SendMessage 受信 + TaskList 確認（メイン）/ シグナルファイル（補助） | [monitoring.md §Agent Teams モード](./references/monitoring.md#agent-teams-モードin-process) |
 | Agent Teams tmux | シグナルファイル + bash 待機ループ（必須）+ SendMessage（内容） | [monitoring.md §tmux モード](./references/monitoring.md#tmux-モード) |
-| Platform hooks（補助） | hooks → シグナルファイル自動生成 | [monitoring.md §Platform hooks](./references/monitoring.md#platform-hooks補助オプション) |
+| Platform hooks（イベント signalizer） | hooks → シグナルファイル自動生成（常時） | [monitoring.md §Platform hooks](./references/monitoring.md#platform-hooksイベント-signalizer) |
 
 ### シグナルファイル命名規則（3系統サマリ）
 

--- a/.claude/skills/einja-team-exec/references/monitoring.md
+++ b/.claude/skills/einja-team-exec/references/monitoring.md
@@ -15,20 +15,23 @@ Lead/Director/Worker 間で使用するシグナルファイルは、用途別�
 | Agent Teams系（Director → Lead） | `director-{ID}-complete.signal` | Director がタスク完了を SendMessage 送信後に作成 | Director | Lead の bash 待機ループ（tmuxモード）/ 補助監視（in-process） |
 | Agent Teams系（Director → Lead） | `director-{ID}-error.signal` | Director がエラー発生時に作成 | Director | 同上 |
 | Agent Teams系（Director → Lead） | `director-{ID}-idle.signal` | Director がアイドル状態を通知 | Director | 同上 |
-| Platform hooks系（補助） | `teammate-idle-{TEAMMATE}.signal` | `TeammateIdle` hook が自動作成 | Claude Code platform | Lead の補助監視 |
-| Platform hooks系（補助） | `task-{TASK_ID}-completed.signal` | `TaskCompleted` hook が自動作成 | Claude Code platform | Lead の補助監視 |
+| Platform hooks系（signalizer） | `teammate-idle-{TEAMMATE}.signal` | `TeammateIdle` hook が自動作成（Agent Teams 有効時は**常時生成**・モード判定なし） | Claude Code platform | Lead が `MONITOR_MODE` に応じて解釈（tmux=起床トリガー / in-process=取りこぼし補助） |
+| Platform hooks系（signalizer） | `task-{TASK_ID}-completed.signal` | `TaskCompleted` hook が自動作成（Agent Teams 有効時は**常時生成**・モード判定なし） | Claude Code platform | Lead が `MONITOR_MODE` に応じて解釈（tmux=起床トリガー / in-process=取りこぼし補助） |
 
 ### in-process モードでのシグナルファイル扱い
 
-Agent Teams in-process モードでは Platform hooks 設定時にシグナルファイルが自動作成されるが、
-これは **補助的な役割** に留まる。メイン通信路は SendMessage 受信であり、シグナルファイルは
-SendMessage の取りこぼし検知や TaskList 監視のフォールバックとして使用する。
+Platform hooks 設定時、hooks は実効モードを判定せず **Agent Teams 有効時は常にシグナルを生成する**（signalizer）。
+in-process モードでは、これらシグナルは **補助的な役割** に留まる。メイン通信路は SendMessage 受信であり、
+シグナルファイルは SendMessage の取りこぼし検知や TaskList 監視のフォールバックとして使用する（無視してもよい）。
 
 | モード | メイン通信 | シグナルファイル |
 |-------|----------|----------------|
-| tmuxモード | SendMessage + シグナルファイル | **必須**（bash 待機ループ駆動） |
-| in-processモード（hooks有） | SendMessage 受信 | 補助（取りこぼし検知用） |
+| tmuxモード | SendMessage + シグナルファイル | **起床トリガー**（bash 待機ループ駆動） |
+| in-processモード（hooks有） | SendMessage 受信 | 補助（取りこぼし検知用・無視可） |
 | in-processモード（hooks無） | SendMessage 受信のみ | 不使用 |
+
+> **注**: 現行の einja settings では hooks は常時有効・常時生成される（Agent Teams 有効時）。
+> 上記「hooks無」は hooks 未設定の外部環境向けの記述として残している。
 
 ---
 
@@ -108,9 +111,14 @@ done
 
 ---
 
-## Platform hooks（補助・オプション）
+## Platform hooks（イベント signalizer）
 
-`TeammateIdle` / `TaskCompleted` hook（v2.1.33+ で公式サポート確認済み — 出典: https://code.claude.com/docs/en/hooks ）を補助的に使用可能。
+`TeammateIdle` / `TaskCompleted` hook（v2.1.33+ で公式サポート確認済み — 出典: https://code.claude.com/docs/en/hooks ）は、
+**実効モードを判定せず、Agent Teams 有効時は常時シグナルを生成する「イベント signalizer」** として動作する。
+hooks 自体はモード判定を行わず、生成されたシグナルを **Lead が自分で resolve した `MONITOR_MODE` に応じて解釈** する:
+
+- **tmux モード**: シグナルを **起床トリガー** として使用（bash 待機ループを即座に抜けさせる）
+- **in-process モード**: SendMessage がメイン通信路。シグナルは **取りこぼし検知の補助** として使用（無視してもよい）
 
 ```jsonc
 // settings.json
@@ -128,4 +136,7 @@ done
 }
 ```
 
-**必須ではない** — hooks 未設定でも SendMessage + シグナルファイル方式で動作する。
+> **注**: 上記 settings.json 例の `touch ~/.einja/sessions/$SESSION/...` は **hooks 未設定の外部環境向けの最小構成例**であり、シグナルファイル名が `$SESSION` / `$TASK_ID` / `$TEAMMATE` の素の env 展開に依存する。einja 同梱の `.claude/hooks/einja/task-completed.sh` / `teammate-idle.sh` はこれより高機能で、**stdin JSON（`team_name` / `task_id` / `teammate_name`）を解析して動的にシグナルファイル名・session dir を決定**する（詳細: [`agent-teams-env.md`](../../../../docs/einja/instructions/agent-teams-env.md) 「3-0. フックの入力」）。einja 環境では同梱フックが使われるため、この最小例を手動設定する必要はない。
+
+現行の einja settings では上記 hooks は常時有効・常時生成される。hooks 未設定の外部環境でも、
+tmux モードでは Director が自前で `touch` するシグナルファイル、in-process モードでは SendMessage により動作する。

--- a/docs/einja/instructions/agent-teams-env.md
+++ b/docs/einja/instructions/agent-teams-env.md
@@ -14,6 +14,9 @@ Agent Teams（`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`）下で `einja-team-exec
 |--------|------|------|---------------|
 | `EINJA_SESSION_ID` | **必須**（tmuxモード時） | フックが書き込むシグナルファイルの保存ディレクトリ（`$HOME/.einja/sessions/${EINJA_SESSION_ID}/signals/`）を決定するセッション識別子。Lead と全 Teammate で同じ値を共有する | Lead 起動時に export。`einja-team-exec` / `einja-issue-team-exec` Skill が `TeamCreate` の `instructions` で各 Teammate にも export させる |
 | `EINJA_AGENT_ROLE` | 推奨 | 現在のインスタンスのロール識別子（例: `lead` / `director` / `worker`）。複数 Skill が同じシェルから起動された場合の動作切り分け・デバッグログのタグ付けに使用 | Lead 起動時 / Teammate spawn 時の `instructions` で export |
+| `EINJA_TEAMMATE_MONITOR_MODE` | 任意 | **einja Lead の監視ループ挙動**（`tmux` / `in-process`）を明示指定する。未指定時は settings.json の top-level `teammateMode`（project→user）→ `auto` の順で解決し、`auto`/`tmux` は `$TMUX` + `tmux list-panes` 成功で `tmux`、失敗で `in-process` へ降格判定する（詳細: [`einja-team-exec/SKILL.md` Step 1-A](../../../.claude/skills/einja-team-exec/SKILL.md) 「Lead 監視モード resolve」） | Lead 起動時に export（任意） |
+
+> **`teammateMode` / `--teammate-mode` / `EINJA_TEAMMATE_MONITOR_MODE` の役割分離**: `--teammate-mode`（CLI）と settings.json の `teammateMode` は **Claude Code 本体の teammate 起動モード**（tmux pane を split するか in-process で動かすか）を制御する。一方 `EINJA_TEAMMATE_MONITOR_MODE` は **einja Lead の監視ループ挙動**（シグナルファイル待機を駆動するか SendMessage/TaskList を主にするか）を制御する別レイヤーの設定であり、未指定時のフォールバックとして本体の `teammateMode` を参照する。
 
 ### 1-2. Claude Code プラットフォームが自動で提供する変数
 
@@ -22,10 +25,11 @@ Agent Teams（`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`）下で `einja-team-exec
 | 変数名 | 提供元 | 役割 |
 |--------|--------|------|
 | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` | プラットフォーム / ユーザー | Agent Teams 機能の有効化フラグ。`1` 以外の場合フックは即 exit 0 |
-| `CLAUDE_CODE_TEAMMATE_MODE` | プラットフォーム | `tmux` / `in-process` のチーム実行モード。`tmux` 以外の場合フックはシグナルを生成しない |
-| `CLAUDE_CODE_TASK_ID` | プラットフォーム（v2.1.33+） | `TaskCompleted` フックで参照する Task ID。`task-completed.sh` がシグナルファイル名 `task-${CLAUDE_CODE_TASK_ID}-completed.signal` に埋め込む |
-| `CLAUDE_CODE_TEAMMATE_NAME` | プラットフォーム（v2.1.33+） | `TeammateIdle` フックで参照する Teammate 名。`teammate-idle.sh` がシグナルファイル名 `teammate-idle-${CLAUDE_CODE_TEAMMATE_NAME}.signal` に埋め込む |
+| `CLAUDE_CODE_TASK_ID` | プラットフォーム（v2.1.33+） | `TaskCompleted` フックの Task ID **フォールバック**。フックは stdin JSON の `task_id` を優先し、未提供時のみこの env var を参照する。`task-completed.sh` が解決した値をシグナルファイル名 `task-${task_id}-completed.signal` に埋め込む |
+| `CLAUDE_CODE_TEAMMATE_NAME` | プラットフォーム（v2.1.33+） | `TeammateIdle` フックの Teammate 名 **フォールバック**。フックは stdin JSON の `teammate_name` を優先し、未提供時のみこの env var を参照する。`teammate-idle.sh` が解決した値をシグナルファイル名 `teammate-idle-${teammate_name}.signal` に埋め込む |
 | `CLAUDE_CODE_SESSION_ID` / `CLAUDE_SESSION_ID` | プラットフォーム（提供される場合） | `EINJA_SESSION_ID` 未設定時のフォールバック解決順序の一部 |
+
+> **`CLAUDE_CODE_TEAMMATE_MODE` について**: 従来 einja は `.claude/settings.json` の `env` でこの変数を `tmux` として補完していたが、これは Claude Code が**公式に提供する env var ではなく**フックにも渡らないため廃止した。チーム実行モードは Lead 起動時の `claude --teammate-mode tmux` で指定する（後述の「5. 下流リポジトリでのセットアップ手順」を参照）。
 
 ---
 
@@ -52,12 +56,26 @@ export EINJA_AGENT_ROLE="director"   # または "worker"
 
 ## 3. シグナルファイル仕様
 
+### 3-0. フックの入力（stdin JSON が主）
+
+公式 Claude Code hooks（`TaskCompleted` / `TeammateIdle`）は **stdin に JSON を渡す**のが主入力である（公式: https://code.claude.com/docs/en/hooks ）。`task-completed.sh` / `teammate-idle.sh` はこの JSON を `jq` 等で解析し、以下のフィールドを参照する:
+
+| フィールド | 用途 |
+|-----------|------|
+| `team_name` | 命名サフィックス（`-directors` / `-workers`）を除去して session id を復元する |
+| `teammate_name` | `TeammateIdle` のシグナルファイル名に埋め込む Teammate 名 |
+| `task_id` | `TaskCompleted` のシグナルファイル名に埋め込む Task ID |
+
+stdin JSON にフィールドが含まれない場合のみ、対応する env var（`CLAUDE_CODE_TASK_ID` / `CLAUDE_CODE_TEAMMATE_NAME`）にフォールバックする。env var 依存を前提とせず、まず stdin JSON を主入力として扱うこと。
+
+### 3-1. シグナルファイルの保存先
+
 フックが書き込むシグナルファイルは Lead の監視ループが poll する。
 
 | ディレクトリ | `$HOME/.einja/sessions/${EINJA_SESSION_ID}/signals/` |
 |------------|-----------------------------------------------------|
-| TaskCompleted | `task-${CLAUDE_CODE_TASK_ID}-completed.signal` |
-| TeammateIdle | `teammate-idle-${CLAUDE_CODE_TEAMMATE_NAME}.signal` |
+| TaskCompleted | `task-${task_id}-completed.signal`（`task_id` は stdin JSON 優先、未提供時 `CLAUDE_CODE_TASK_ID`） |
+| TeammateIdle | `teammate-idle-${teammate_name}.signal`（`teammate_name` は stdin JSON 優先、未提供時 `CLAUDE_CODE_TEAMMATE_NAME`） |
 
 - 生成は `touch` のみ（中身は空）。`mtime` を Lead が確認することで完了/アイドルを検知する
 - ディレクトリは `mkdir -p` で都度生成される
@@ -83,8 +101,8 @@ tail -n 50 /tmp/einja-hooks-debug.log
 | 症状 | 確認ポイント |
 |------|------------|
 | Lead がいつまでも完了を検知しない | デバッグログに `EINJA_SESSION_ID=<set>` があるか。なければ `instructions` の export 漏れ |
-| `task-${...}` のシグナル名が `task-unknown-...` になる | `CLAUDE_CODE_TASK_ID` が提供されていない（Claude Code バージョンが古い可能性） |
-| `teammate-idle-unknown.signal` が生成される | `CLAUDE_CODE_TEAMMATE_NAME` が提供されていない（同上） |
+| `task-${...}` のシグナル名が `task-unknown-...` になる | stdin JSON に `task_id` が無く、フォールバックの `CLAUDE_CODE_TASK_ID` も未提供（Claude Code バージョンが古い可能性） |
+| `teammate-idle-unknown.signal` が生成される | stdin JSON に `teammate_name` が無く、フォールバックの `CLAUDE_CODE_TEAMMATE_NAME` も未提供（同上） |
 | ログ自体が空 / 存在しない | フック自体が呼ばれていない。`settings.json` の `hooks` 設定を確認 |
 
 ### ログ運用上の注意
@@ -103,9 +121,14 @@ tail -n 50 /tmp/einja-hooks-debug.log
    export EINJA_SESSION_ID="$(date +%Y%m%d-%H%M%S)-$$"   # 任意の一意な値
    export EINJA_AGENT_ROLE="lead"
    ```
-2. `einja-team-exec` / `einja-issue-team-exec` Skill を起動
-3. Skill が内部で `TeamCreate` の `instructions` に Teammate 用 export を含めるため、ユーザー側で追加設定は不要
-4. 動作確認: `/tmp/einja-hooks-debug.log` にフック起動ログが現れること、`$HOME/.einja/sessions/${EINJA_SESSION_ID}/signals/` にシグナルファイルが生成されることを確認
+2. Lead（チーム実行 Skill を起動する Claude Code インスタンス）を起動する際、チーム実行モードを `--teammate-mode tmux` で明示する
+   ```bash
+   claude --teammate-mode tmux
+   ```
+   - CLI オプションは `settings.json` の設定より**優先**される。これを指定しないと teammate モードが `auto` で起動し、silent な in-process fallback（フックが発火せず Lead がシグナルを受け取れない状態）になり得るため、tmux ベースの監視を確実に動かすには明示すること
+3. `einja-team-exec` / `einja-issue-team-exec` Skill を起動
+4. Skill が内部で `TeamCreate` の `instructions` に Teammate 用 export を含めるため、ユーザー側で追加設定は不要
+5. 動作確認: `/tmp/einja-hooks-debug.log` にフック起動ログが現れること、`$HOME/.einja/sessions/${EINJA_SESSION_ID}/signals/` にシグナルファイルが生成されることを確認
 
 ---
 

--- a/docs/einja/instructions/issue-exec-protocol.md
+++ b/docs/einja/instructions/issue-exec-protocol.md
@@ -302,38 +302,54 @@ Agent Teams版（einja-issue-team-exec）: Worker → Director(Teammate) → Lea
 - **全リトライ失敗時**: abort（エラーをManagerにエスカレーション）
 - **jitter**: `sleep $((RANDOM % 2 + 1))` 相当のランダム待機
 
-### 12.3 IssueBranchBase自動同期プロトコル
+### 12.3 IssueBranchBase 取り込みプロトコル（Phase境界同期 + 最終PRゲート）
 
-Managerの監視ループでIssueBranchBaseの進行を検知し、Issueブランチに取り込むプロトコル。
+IssueBranchBase（develop/main 等）の進行を **受動検知に頼らず**、(1) 各Phase境界、(2) 最終PR作成直前 の2つの確定タイミングで能動的に取り込む。これにより Issueブランチがbaseから大きく遅れて最終マージで巻き戻しが起きる問題を構造的に防ぐ。すべて **merge-only**（`issue/{N}` は共有ブランチのため rebase/force-push 禁止）・**冪等**（behind=0ならスキップ）。
 
-#### 同期手順
+#### 12.3.1 Phase境界強制同期
 
-1. **進行検知**: Manager監視ループ内で `git fetch origin` 実行時、`origin/{IssueBranchBase}` の HEAD が前回確認時から進行していることを検知
-2. **Issueブランチへの取り込み**: Manager worktree内で以下を実行:
-   ```bash
-   cd <manager-worktree>
-   git fetch origin
-   git merge origin/{IssueBranchBase}
-   git push origin issue/{N}
-   ```
-3. **成功時**: 各active Workerに `sync_required` を通知（tmux版）/ Teammate に通知（Agent Teams版）。Phaseブランチは直接更新しない
-4. **Workerの同期（tmux版）/ Directorの同期（Agent Teams版）**: 安全ポイント（タスク開始前・マージ直後）で以下を実行:
-   ```bash
-   cd <phase-worktree>
-   git fetch origin
-   git merge origin/issue/{N}
-   git push origin issue/{N}-phase{M}
-   ```
-   > tmux版の場合、Manager が Phase ブランチを最新化すれば Worker 側の個別同期は不要（Worker はタスク開始前に Manager が最新 Phase ブランチからブランチを切るため）
-5. **merge失敗時**: `einja-conflict-resolver` Skill で解消 → 解消不可ならユーザーにエスカレーション
+Phase完了 → 次Phase着手前に、Manager（tmux版）/ Lead（Agent Teams版）が **必ず** 以下を実行:
+
+```bash
+# ※ issue/{N} をチェックアウトしている worktree（Manager/Lead worktree）で実行すること
+git fetch origin
+# issue/{N} が origin/{IssueBranchBase} より遅れているコミット数
+BEHIND=$(git rev-list --count "issue/{N}..origin/{IssueBranchBase}")
+if [ "$BEHIND" -gt 0 ]; then
+  git merge --no-edit "origin/{IssueBranchBase}"   # 衝突→einja-conflict-resolver Skill で解消（解消不可ならユーザーにエスカレーション）
+  git push origin "issue/{N}"                        # lock系エラー→§12.2 リトライポリシー（最大3回）
+fi
+# 次Phaseブランチ issue/{N}-phase{M+1} は、最新化後の issue/{N} から作成/追従する（merge-only・冪等）
+```
+
+- behind=0 のときは merge/push をスキップ（冪等）
+- push 成功を確認してから次Phaseブランチを作成すること（古い `issue/{N}` を参照しないため）
+
+#### 12.3.2 最終PR作成前 遅れ検知ゲート（必須）
+
+`einja-create-pr` 実行直前に、Manager/Lead が **必ず** 以下を実行:
+
+```bash
+# ※ issue/{N} をチェックアウトしている worktree（Manager/Lead worktree）で実行すること
+git fetch origin
+BEHIND=$(git rev-list --count "issue/{N}..origin/{IssueBranchBase}")
+echo "issue/{N} は origin/{IssueBranchBase} から ${BEHIND} コミット遅れ"
+if [ "$BEHIND" -gt 0 ]; then
+  echo "[WARN] ${BEHIND}件のbase更新が未取込。巻き戻しリスクがあるため取り込みます"
+  git merge --no-edit "origin/{IssueBranchBase}"   # 衝突→einja-conflict-resolver
+  git push origin "issue/{N}"                        # lock系→§12.2
+fi
+# この後にPR作成 → CONFLICTING/DIRTY なPRを構造的に防ぐ
+```
 
 #### 同期のタイミング
 
 | トリガー | 実行者 | 動作 |
 |---------|--------|------|
-| `git fetch` で IssueBranchBase の進行を検知 | Manager | Issueブランチに merge → Worker（tmux版）/ Teammate（Agent Teams版）に通知 |
-| `sync_required` 通知の受信 | Worker（tmux版）/ Director（Agent Teams版） | 安全ポイントで Phase ブランチに merge |
-| タスク開始前 | Manager（tmux版）/ Director（Agent Teams版） | Phase ブランチの最新を確認 |
+| Phase完了 → 次Phase着手前 | Manager（tmux版）/ Lead（Agent Teams版） | §12.3.1: fetch → behind判定 → merge → push（冪等） |
+| 最終PR作成直前（einja-create-pr前） | Manager（tmux版）/ Lead（Agent Teams版） | §12.3.2: fetch → behind判定 → 警告 → merge → push |
+
+> 旧「Manager監視ループによるbase進行の受動検知 → sync_required 通知」モデルは廃止。base取り込みは上記2タイミングの能動同期に一本化する。
 
 ### 12.4 複数Issue並行時のマージ順序
 

--- a/docs/einja/instructions/issue-exec-workflow.md
+++ b/docs/einja/instructions/issue-exec-workflow.md
@@ -212,7 +212,7 @@ Human（回答入力）
 ```
 Worker-1.1 作業中
  │
- ├─ 0. git rebase origin/issue/123-phase1（最新取り込み）
+ ├─ 0. git rebase origin/issue/123-phase1（task/123-1.1 を Phaseブランチへ追従。taskブランチは単独所有のため rebase 可）
  ├─ 1. task-exec 完了 → task/123-1.1 に commit & push
  ├─ 2. CI 完了待機（gh run list ポーリング）
  ├─ 3. gh pr create --base issue/123-phase1 --head task/123-1.1
@@ -245,7 +245,6 @@ Director 検知（ステータスファイル: status=awaiting_review）
  │   └─ auto: CI通過確認後に gh pr merge --squash 実行
  │
  ├─ マージ検知後:
- │   ├─ 他 active Worker にステータスで sync_required 通知
  │   ├─ タスク worktree 削除 + tmux window kill
  │   ├─ GitHub Issue チェックボックス更新
  │   └─ 依存タスク起動判定 → 新 Worker 起動
@@ -258,7 +257,8 @@ Manager 検知
  ├─ マージモードに応じた処理
  ├─ マージ後: Phase worktree 削除
  ├─ 他 active Phase に変更伝播
- └─ 次 Phase 起動 or 全完了 → 最終 PR 作成
+ ├─ Phase境界強制同期（§12.3.1）: 次Phase着手前に issue/123 を base から最新化（fetch→behind判定→merge→push、merge-only・冪等）
+ └─ 次 Phase 起動 or 全完了 → 最終 PR 作成（最終PR前は §12.3.2 ゲートで base 取込）
 ```
 
 ---

--- a/docs/einja/steering/branch-strategy.md
+++ b/docs/einja/steering/branch-strategy.md
@@ -375,23 +375,25 @@ IssueBranchBase (main)
 | `issue/{N}-phase{M}` | **merge-only** | Manager/Teammate（Agent Teams版）とWorkerが参照する共有ブランチ |
 | `task/{N}-{X.Y}` | rebase可 | 単独Worker所有のため安全 |
 
+**base追従は必ず merge で行う**（`issue/{N}` は共有ブランチのため、IssueBranchBase の取り込みに rebase/pull --rebase を使わない。rebase可なのは単独所有の `task/{N}-{X.Y}` のみ）。
+
 ### マージ戦略: 楽観的並行マージ
 
 - 先にIssueBranchBase（main等）にマージしたIssueが勝ち
 - 後続Issueはmainの最新を `merge` で取り込み、PR を更新してからマージ
 - Issue間依存がある場合: `--base-branch` でIssueブランチを指定するか、人間が実行順序を制御
 
-### IssueBranchBase自動同期
+### IssueBranchBase 取り込み（Phase境界同期 + 最終PRゲート）
 
-Managerの監視ループでIssueBranchBaseの進行を検知し、以下を実行する:
+IssueBranchBase（develop/main 等）の進行を受動検知に頼らず、(1) 各Phase境界（Phase完了→次Phase着手前）、(2) 最終PR作成直前 の2タイミングで能動的に取り込む。すべて **merge-only・冪等**（`git rev-list --count "issue/{N}..origin/{IssueBranchBase}"` が 0 ならスキップ）。
 
-1. **進行検知**: `git fetch origin` で `origin/{IssueBranchBase}` の変更を確認
-2. **Issueブランチへの取り込み**: `issue/{N}` ブランチで `git merge origin/{IssueBranchBase}` を実行
-3. **成功時**: 各Workerにsync通知（tmux版）/ Teammateに通知（Agent Teams版）。Phaseブランチは直接更新しない
-4. **Managerの同期**: 安全ポイント（タスク開始前・マージ直後）でPhaseブランチを同期し、タスクブランチ作成時に最新を反映
-5. **merge失敗時**: `einja-conflict-resolver` Skill で解消 → 解消不可ならユーザーにエスカレーション
+1. **Phase境界強制同期**: Manager（tmux版）/ Lead（Agent Teams版）が、Phase完了→次Phase着手前に `git fetch origin` → behind判定 → `git merge --no-edit origin/{IssueBranchBase}` → `git push origin issue/{N}`。push成功確認後に次Phaseブランチを作成。
+2. **最終PR前ゲート**: `einja-create-pr` 直前に同じ behind判定→merge→push を実行し、CONFLICTING/DIRTY なPRを構造的に防ぐ。
+3. **merge失敗時**: `einja-conflict-resolver` Skill で解消 → 解消不可ならユーザーにエスカレーション。
 
-詳細手順は [Issue実行共通プロトコル](../instructions/issue-exec-protocol.md) の「IssueBranchBase自動同期プロトコル」を参照。
+旧「Managerの監視ループによる受動検知→sync通知」モデルは廃止。
+
+詳細手順は [Issue実行共通プロトコル](../instructions/issue-exec-protocol.md) の §12.3「IssueBranchBase 取り込みプロトコル」を参照。
 
 ---
 

--- a/docs/einja/steering/commit-rules.md
+++ b/docs/einja/steering/commit-rules.md
@@ -20,6 +20,8 @@
    git pull --rebase
    ```
 
+   > **共有ブランチは merge で最新化**: `git pull --rebase` は個人/feature ブランチ向け。**共有ブランチ（`issue/{N}` / `issue/{N}-phase{M}`）の最新化・IssueBranchBase 追従は rebase ではなく `merge` を使う**（複数エージェント・複数 worktree の参照を壊さないため）。詳細は steering/branch-strategy.md「ブランチ操作安全ルール」を参照。
+
 3. **現在の状態確認**
    ```bash
    git status

--- a/docs/plans/202606/20260610-issue-exec-base-sync-and-teammate-monitor.plan.md
+++ b/docs/plans/202606/20260610-issue-exec-base-sync-and-teammate-monitor.plan.md
@@ -1,0 +1,153 @@
+# issue-exec系 信頼性向上: ①ベースブランチ遅延対策 ②teammate監視モードの構造修正
+
+> 本Planは独立した2テーマを扱う。**別コミット・別PR**に分離して実装する（ファイル無関係・レビュー観点別・混ぜると巨大PRで巻き戻しリスク）。
+> 本Planは前セッションで策定・レビュー（einja-review-plan + codex-agent、**MINOR判定・指摘反映済み**）まで完了している。行番号アンカーはタスクA0/B0（grep全棚卸し・実在確認）で実行時に再確認するため、行ドリフトには自己修正で対応する。
+
+## Context
+
+下位リポジトリで顕在化した2問題。最新公式ドキュメント調査（claude-code-guide）+ Codex とのダブルチェックで設計を収束済み。
+
+### 問題1: Issueブランチのベースブランチ遅延
+`issue/{N}` で長期作業するとベース（develop/main）から遅れ、最終マージで大量コンフリクト・他セッション作業の巻き戻しが起きる。実害（eenchow-bot）: `issue/343` が develop から **70 commit 遅れ**、最終PR #412 が CONFLICTING/DIRTY・`.env.develop` 巻き戻しリスク。team/非team両方。根本原因は `issue-exec-protocol.md §12.3` に同期プロトコルの定義はあるが各SKILLに実装場所が無く、§12.3 自体が「Manager監視ループでbase進行を検知」という受動モデルで事実上機能していないこと。
+
+### 問題2: teammate表示モード検出の構造的不整合
+`einja-team-exec/SKILL.md` L72-82 と hooks（task-completed.sh/teammate-idle.sh L30）が、**Claude Code が公式提供しない env var `CLAUDE_CODE_TEAMMATE_MODE`** を二重に判定。フックは `${:-tmux}` でtmux仮定、SKILLは env空→in-process判定、で挙動がズレる。下位リポジトリで teammateMode=auto（settings top-level）の時、フックはシグナル生成するのにSKILLがin-process誤判定し tmux pane監視をしない。
+
+**公式調査で確定した事実（根拠: code.claude.com/docs/en/agent-teams, hooks, env-vars, GitHub Issues #29207/#29660/#32987/#23572/#24301）:**
+- `teammateMode` = tmux/in-process/**auto（デフォルト）**。auto は tmux内 or iTerm2 で split panes。
+- **`CLAUDE_CODE_TEAMMATE_MODE` は公式提供されない env var**（einjaが settings env で補完）。hooks にも渡らない。
+- hooks(TaskCompleted/TeammateIdle)は **stdin JSON で team_name/teammate_name/task_id を受け取る**（公式）。
+- Agent Teams の **環境変数の自動継承は実装不安定**（#29660/#32987）。instructions export 経由も hook 伝播は保証されない（debug log で実績確認できず）。
+- teammate の実効モード（pane/in-process）を hook/skill から確実判定する公式手段は**無い**。#29207 で tmux 明示でも silent in-process fallback あり。
+
+→ 結論: **「実効モードを当てに行く」設計は不可能**。hooks は判定をやめ常にシグナル生成、**Lead Skill だけが einja の監視モードを決める**。
+
+## 変更内容
+
+### ───────── PR-A: ベースブランチ遅延対策（問題1）─────────
+
+**方針1: Phase境界強制同期（§12.3.1）** — Phase完了→次Phase着手前に Manager/Lead が必ず:
+```bash
+git fetch origin
+BEHIND=$(git rev-list --count "issue/{N}..origin/{baseBranch}")  # issue/{N}がbaseより遅れているコミット数
+if [ "$BEHIND" -gt 0 ]; then
+  git merge --no-edit "origin/{baseBranch}"   # 衝突→einja-conflict-resolver
+  git push origin "issue/{N}"                  # 失敗→§12.2リトライ
+fi
+# 次Phaseブランチは最新化後の issue/{N} から作成/追従（merge-only・冪等）
+```
+
+**方針2: 最終PR作成前 遅れ検知ゲート（§12.3.2・必須）** — `einja-create-pr` 直前に:
+```bash
+git fetch origin
+BEHIND=$(git rev-list --count "issue/{N}..origin/{baseBranch}")
+echo "issue/{N} は origin/{baseBranch} から ${BEHIND} コミット遅れ"
+if [ "$BEHIND" -gt 0 ]; then
+  echo "[WARN] ${BEHIND}件のbase更新未取込。巻き戻しリスク。取込実行"
+  git merge --no-edit "origin/{baseBranch}"; git push origin "issue/{N}"
+fi
+# この後PR作成 → CONFLICTING/DIRTY PRを構造的に防ぐ
+```
+
+**方針3: 監視ループ検知モデルの整理** — §12.3 の「Manager監視ループでbase進行検知→sync_required通知」を方針1/2に置換。`sync_required` のうち base同期通知分は廃止（memory obs 1496: workflow図のsync_required通知は未実装）。
+
+**精査で確定した既存記述の扱い（レビュー指摘を精査・短絡を回避）:**
+- `rebase` 記述（workflow.md L215/L275, issue-exec SKILL L756）は**全て `task/{N}-{X.Y}`（rebase可）文脈** → 残す。Phase境界 merge のコンフリクト行を追加する。
+- `sync_required`（workflow.md L248, issue-exec SKILL L854）= 旧監視ループ概念・未実装 → 削除/方針1整合に書換。
+
+| ファイル | 変更 |
+|---------|------|
+| `docs/einja/instructions/issue-exec-protocol.md` | **§12.3（L305-336）改訂**: §12.3.1 Phase境界強制同期 / §12.3.2 最終PRゲート。sync_required（L319/L335）削除。タイミング表差替 |
+| `docs/einja/steering/branch-strategy.md` | L384-394「自動同期」を方針1/2へ。L376（merge-only表）直後に「base追従は必ずmerge」1文 |
+| `docs/einja/instructions/issue-exec-workflow.md` | L248 sync_required削除、L215/L275 はtaskブランチ文脈と明記（残す）、Phase境界同期の追記 |
+| `.claude/skills/einja-issue-exec/SKILL.md` | 最終PRゲート（Step8 L613-623直前）、Phase境界同期（Step7 L604-606）、L854 sync_required書換、L756 mergeコンフリクト行追加、ツリー注記 |
+| `.claude/skills/einja-issue-team-exec/SKILL.md` | base取込同期（Step6 L541-542間, push成功確認後にL543へ）、最終PRゲート（Step8 L573-575間） |
+| `.claude/skills/einja-issue-team-exec/director-prompt.md` | L43-54付近に「base参照前にfetch済み前提」1文（任意） |
+| `docs/einja/steering/commit-rules.md` | L18-21付近に「共有ブランチの最新化はpull --rebaseでなくmerge」1文 |
+
+### ───────── PR-B: teammate監視モードの構造修正（問題2）─────────
+
+**設計核: hooks は判定せず常にシグナル生成。Lead Skill だけが監視モードを決める。**
+
+**B-1. hooks（task-completed.sh / teammate-idle.sh）**
+- `${CLAUDE_CODE_TEAMMATE_MODE:-tmux}` モード判定を**削除**
+- **session id 解決（signal dir決定）**: `EINJA_SESSION_ID`(=`issue-{N}`) を**主経路**。未設定時のみ stdin JSON の `team_name` から命名サフィックス（`-directors`/`-workers` 等、B0で規則確認）を除去して復元 → `CLAUDE_CODE_SESSION_ID` → `CLAUDE_SESSION_ID`。**`team_name` をそのまま signal dir に使わない**（Lead が見る `issue-{N}` とズレるため）
+- task_id/teammate_name は **stdin JSON 優先**（CLAUDE_CODE_TASK_ID 等は env fallback）
+- セッション単位 signal dir に**常にシグナル生成**（in-process時は Lead が無視するので無害）
+```bash
+HOOK_INPUT="$(cat)"; json_get(){ node -e '...' "$1" <<<"$HOOK_INPUT" || jq ... ; }
+# signal dir は EINJA_SESSION_ID(issue-{N}) 主経路。未設定時のみ team_name からサフィックス除去で復元
+SESSION_ID="${EINJA_SESSION_ID:-}"
+[ -z "$SESSION_ID" ] && SESSION_ID="$(json_get team_name | sed -E 's/-(directors|workers)$//')"
+[ -z "$SESSION_ID" ] && SESSION_ID="${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
+[ -n "$SESSION_ID" ] || exit 0
+# mode判定なし。常に signal 生成（stdin JSON 全文を書く）
+```
+
+**B-2. `einja-team-exec/SKILL.md` Step 1-A**
+- 「表示モード検出（env var判定）」→「**Lead監視モード resolve**（`EINJA_TEAMMATE_MONITOR_MODE`）」に変更
+- resolver: `EINJA_TEAMMATE_MONITOR_MODE` > top-level teammateMode(project→user) > auto。**auto/tmux は `$TMUX`非空 + `tmux list-panes`成功で tmux、それ以外/失敗で in-process 降格**
+- **tmux監視でも SendMessage/TaskList poll を併用**（#29207 silent fallback保険）
+
+**B-3. `einja-team-exec/references/monitoring.md`**（存在確認の上）
+- hooks を「実効モード依存の監視」でなく「**イベント signalizer（常時生成）**」と再定義。in-process時は signals無視、tmux時は wake trigger
+
+**B-4. `einja-issue-team-exec/SKILL.md`** — team-exec の新監視方針を参照する記述に更新（L78付近）
+
+**B-5. `docs/einja/instructions/agent-teams-env.md` + `.claude/settings.json`**
+- agent-teams-env.md: `CLAUDE_CODE_TEAMMATE_MODE`「プラットフォーム提供」記述を**削除/訂正**（公式提供されない）。hook 入力は **stdin JSON 前提**に修正（env var 依存記述を削除）。`claude --teammate-mode tmux` は **Lead起動時オプション**として記載（auto silent fallback回避・CLI>settings）
+- `.claude/settings.json` L4: env ブロックの `CLAUDE_CODE_TEAMMATE_MODE: "tmux"` を**削除**（hooks/SKILLが参照しなくなるため不要。残すとdocs訂正と矛盾）。※settings.json は cli-package-specs 対象
+
+**再利用資産**: einja-conflict-resolver、§12.2リトライ、git rev-list --count（新規ツール/Skill無し）。
+**配布**: 全て原本。ビルド時 presets/default へ自動コピー（直接編集しない）。hooks/SKILL は cli-package-specs（二重管理禁止）準拠。
+
+## タスク概要
+
+- **0-0**: TaskCreate一括登録（PR-A/PR-B別系列・依存明示）
+- **0-1**: Plan配置 `docs/plans/202606/20260610-issue-exec-base-sync-and-teammate-monitor.plan.md`
+- **0-2**: worktree作成 [`_einja-worktree-guide`]
+
+**PR-A（問題1・直列依存あり）**
+- A0: grep全棚卸し（`§12.3`/`sync_required`/`IssueBranchBase`/`rebase`）で対象・文脈確定 [Grep] ← T1前提
+- A1: protocol §12.3改訂 [Task] ← PR-A正本・最優先
+- A2: branch-strategy [Task]（A1と並列可）
+- A3: issue-exec SKILL [Task] / A4: issue-team-exec SKILL [Task] / A5: workflow.md [Task] / A6: director-prompt [Task]（A1後に並列）
+- A7: commit-rules [Task]
+
+**PR-B（問題2・PR-Aと完全独立・並列可）**
+- B0: monitoring.md 等の参照ファイル実在確認 [Glob/Read] ← B前提
+- B1: hooks 2本 [Task] ← PR-B基盤
+- B2: team-exec SKILL 監視モード [Task]（B1後）
+- B3: monitoring.md [Task]（B1後・B2と並列）
+- B4: issue-team-exec SKILL 参照更新 [Task]（B2後）
+- B5: agent-teams-env.md [Task]（B1後・並列可）
+
+**検証（各PR個別に）**: 99-1 [einja-review-code] → 99-2 動作確認 → 99-G コミット承認ゲート [AskUserQuestion] → 99-3 [einja-task-commit]
+
+## 並列実行計画
+
+```
+PR-A: A0 → A1 ∥ A2 → (A3 ∥ A4 ∥ A5 ∥ A6) → A7 → 検証 → PR-A commit
+PR-B: B0 → B1 → (B2 ∥ B3 ∥ B5) → B4 → 検証 → PR-B commit
+制約: B4 は A4 完了後（A4 --先行--> B4。同一ファイルの別箇所編集を直列化）
+```
+- A4とB4は同一ファイル einja-issue-team-exec/SKILL.md だが、A4=Step6/8の同期挿入、B4=L78の監視方針参照で**箇所が別**。**B4をA4完了後に直列化**して同時編集回避（上図の制約に明示）。オーケストレーターが順序を保証。
+- 各サブエージェントに変更対象ファイル明示・他ファイル不可・git add は対象のみを指示。
+
+## リスク・不明点
+
+| リスク | 対応 |
+|-------|------|
+| §12.3旧記述の他参照 | A0 grep棚卸しで確定（rebase=task文脈は残す/sync_required=削除を判別） |
+| team版A4: push前にphase{M+1}を切ると古いissue参照 | merge→push成功確認をphase{M+1}作成の前提に明記 |
+| hooks の stdin JSON フィールド名が実機と差異 | B1着手時にdebug log/公式hooksドキュメントで team_name/teammate_name/task_id を確認。env varフォールバック併設で堅牢化 |
+| monitoring.md 等参照ファイルが存在しない可能性 | B0で実在確認。無ければ team-exec SKILL本体に統合 |
+| instructions export のhook伝播は不確実 | B設計は伝播を前提にしない（hooksはstdin JSON使用）。EINJA_SESSION_IDフォールバックは残すが主経路にしない |
+| #29207 silent fallback | tmux監視でも SendMessage/TaskList poll併用で取りこぼし防止。tmux list-panes失敗で in-process降格 |
+| settings.json読取(node) | fs.readFileSync+JSON.parse（require回避）、jq fallback、project→user優先。JSONCは非対応前提（einja settingsはコメント無し確認済） |
+
+## 検証・動作確認方法
+
+**PR-A**: ①同期コマンドが merge-only・冪等(behind=0スキップ)・conflict-resolver連携・§12.2参照を満たす ②一時repoで rev-list behind判定 + merge挙動dry-run ③`grep -rn "§12.3\|sync_required\|IssueBranchBase"` で旧記述残存と新方針一致を確認
+**PR-B**: ①hooks がmode判定無しでstdin JSONから常時signal生成すること（一時的に擬似JSONをstdin投入し signal生成を確認） ②resolver dry-run: $TMUX有/無・teammateMode tmux/auto/in-process・tmux list-panes失敗で正しく tmux/in-process が出る ③`grep -rn "CLAUDE_CODE_TEAMMATE_MODE"` でhooks/SKILLから判定依存が消えたこと ④agent-teams-env.md が stdin JSON前提に修正されたこと
+**共通**: ⑤ビルドで presets/default 反映確認 ⑥（任意・別途）下位リポジトリで短いIssueを team/非team実行し、Phase境界・最終PR前の同期ログ、env var非設定でも teammate監視が成立することを確認


### PR DESCRIPTION
issue-exec系の信頼性を向上させる独立した2テーマを、**テーマ別の2コミット**で実装。下位リポジトリ（eenchow-bot）で顕在化した実害への対策。

## テーマA: Issueブランチのベースブランチ遅延対策（commit `0f509c7`）

`issue/{N}` が長期作業中に IssueBranchBase(develop/main) から遅れ、最終マージで大量コンフリクト・他セッション作業の巻き戻しが起きる問題（実害: issue/343 が develop から70 commit遅れ、PR #412 が CONFLICTING/DIRTY）。

根本原因は `issue-exec-protocol.md §12.3` の「Manager監視ループでbase進行を受動検知→sync_required通知」モデルが各SKILLに実装場所が無く事実上機能していないこと。これを能動同期に置換:

- **§12.3.1 Phase境界強制同期**: Phase完了→次Phase着手前に `fetch → git rev-list --count でbehind判定 → git merge --no-edit → push`（merge-only・冪等・behind=0スキップ・conflict-resolver連携・§12.2リトライ）
- **§12.3.2 最終PR前ゲート**: `einja-create-pr` 直前に同期し CONFLICTING/DIRTY PR を構造的に防ぐ
- 旧 `sync_required` 受動検知モデルを廃止。`rebase` 記述は `task/{N}-{X.Y}`（単独所有=rebase可）文脈として保全
- 反映先: `issue-exec-protocol.md` / `branch-strategy.md` / `issue-exec-workflow.md` / `commit-rules.md` / `einja-issue-exec` SKILL / `einja-issue-team-exec` SKILL / `director-prompt.md`

## テーマB: teammate監視モードの構造修正（commit `dd72b6f`）

Claude Code が**公式提供しない** env var `CLAUDE_CODE_TEAMMATE_MODE` への二重依存で、hooks（常時tmux仮定）とSKILL（in-process誤判定）の挙動がズレ、`teammateMode=auto` 時に teammate監視が成立しない問題。

公式調査（agent-teams/hooks/env-vars docs + GitHub Issues #29207/#29660/#32987）の結論「実効モードを hook/skill から確実判定する公式手段は無い」に基づき、**hooksは判定をやめ常時シグナル生成、Lead Skillだけが監視モードを決める**構造に変更:

- **hooks**（task-completed.sh/teammate-idle.sh）: モード判定廃止し常時シグナル生成。stdin JSON（team_name/teammate_name/task_id）を主入力・env var fallback。session id は `EINJA_SESSION_ID` 主経路→team_nameサフィックス除去で復元。**SESSION_ID をサニタイズ（path-traversal防止）**
- **settings.json**: 非公式 `CLAUDE_CODE_TEAMMATE_MODE` を env から削除
- **einja-team-exec SKILL**: 「Lead 監視モード resolve」新設（`EINJA_TEAMMATE_MONITOR_MODE` > settings `teammateMode` > auto、`$TMUX`+`tmux list-panes` で降格判定。tmuxでも SendMessage/TaskList poll 併用で #29207 silent fallback 保険）
- **monitoring.md**: hooks を常時生成の event signalizer として再定義
- **agent-teams-env.md**: stdin JSON前提に修正、`claude --teammate-mode tmux` をLead起動オプションとして追記

## 検証
- **PR-A**: behind判定方向を一時repoで検証（2遅れ→merge後0・冪等）/ sync_required実体記述0件 / §12.3.1・§12.3.2参照が全6ファイル一貫
- **PR-B**: path-traversal遮断確認（悪意あるteam_nameでディレクトリ未生成）/ 正常系シグナル生成 / resolver settings.json実読込→in-process解決 / モード判定ロジック消失
- **共通**: hooks構文OK・settings.json妥当 / presets/default・create-app templates 再生成成功（全116+テスト合格）/ `pnpm prepush` グリーン

## レビュー
観点別並列レビュー（B/C/D/A/G/H）+ Codex独立レビューを両テーマで実施。PR-Bで検出した **MAJOR（SESSION_ID未サニタイズのpath-traversal）** を含む全指摘（MINOR含む）を対応済み。

> 配布: `.claude/`・`docs/einja/` 配下の変更はビルド時に `@einja-inc/dev-cli` / `@einja-inc/create-app` の presets/templates へ自動反映される（cli-package-specs準拠）。